### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,7 @@ jobs:
           find bin -maxdepth 1 -type f -exec cp {} $HOME/.local/bin/. \;
           # cp -r bin ../bin
           cd ..
-          
-          # delete file sin dir so they dont get copied
-          rm -r bin_new/$d/*
+
 
 
       # run .py that calls nb's


### PR DESCRIPTION
env cache now works

**issue**: exes in macOS and linux permission denied
@jtwhite79 
tests runs but there are "permission denied" messages for all the executables called by notebooks in non-win OS's. I am not familiar with non-win OS's. Mind taking a look? I tried adding exes to path during testing, but don't really know what I am doing.