### PR TITLE
part1_14: new notebook on DSI emulation

### DIFF
--- a/autotest/run_notebooks.py
+++ b/autotest/run_notebooks.py
@@ -105,11 +105,13 @@ SECTION_ORDER = {
     ],
 }
 
-# Part1 sections that must run before part1_10 (pilotpoints -> fosm dependency)
+# Part1 section run order. Order matters because later sections reuse results from
+# earlier ones: part1_10 (fosm) needs the pilotpoints runs, and part1_14 (dsi) uses
+# the prior ensemble that part1_13 (ies) leaves in its master directory.
 PART1_ORDER = [
     "part1_01", "part1_02", "part1_03", "part1_04", "part1_05",
     "part1_06", "part1_07", "part1_08", "part1_09", "part1_10",
-    "part1_11", "part1_12", "part1_13",
+    "part1_11", "part1_12", "part1_13", "part1_14",
 ]
 
 

--- a/tutorials/herebedragons.py
+++ b/tutorials/herebedragons.py
@@ -960,13 +960,45 @@ def plot_1to1(pst, title=None):
     return fig, axes
 
 
+def _ies_iterations(m_d, case, kind):
+    """the first and last iteration that PESTPP-IES wrote a `<kind>.csv` file for.
+
+    PESTPP-IES writes one `<case>.<iteration>.<kind>.csv` file per iteration.
+    Iteration 0 is the prior - before any data was assimilated - and the highest
+    numbered file is the posterior. We look at what is actually on disk rather
+    than at NOPTMAX, because PESTPP-IES can stop early.
+    """
+    iters = []
+    for f in os.listdir(m_d):
+        if f.startswith(case + '.') and f.endswith('.' + kind + '.csv'):
+            i = f.split('.')[-3]
+            if i.isdigit():
+                iters.append(int(i))
+    assert len(iters) > 0, f'no {case}.*.{kind}.csv files found in {m_d}'
+    # if only iteration 0 is there then PESTPP-IES never did an update, so there
+    # is no posterior to compare the prior against. Say so, rather than handing
+    # back the same ensemble twice and letting it look like nothing happened
+    assert max(iters) > 0, \
+        f'only found {case}.0.{kind}.csv in {m_d}, so there is no posterior yet. ' + \
+        'Was NOPTMAX zero or negative?'
+    print(f'prior is iteration {min(iters)}, posterior is iteration {max(iters)}')
+    return min(iters), max(iters)
+
+
+def _load_ies_ensembles(m_d, case, kind):
+    lo, hi = _ies_iterations(m_d, case, kind)
+    ensembles = [pd.read_csv(os.path.join(m_d, f'{case}.{i}.{kind}.csv'), index_col=0)
+                 for i in [lo, hi]]
+    # PESTPP-IES sometimes writes the names in upper case
+    ensembles = [en.rename(columns=str.lower) for en in ensembles]
+    return ensembles[0], ensembles[1]
+
+
 def load_ies_obs_ensembles(m_d, case='freyberg'):
     """load the prior and posterior observation ensembles written by PESTPP-IES.
 
-    PESTPP-IES writes one `<case>.<iteration>.obs.csv` file per iteration.
-    Iteration 0 is the prior - the ensemble before any data was assimilated -
-    and the highest numbered file is the posterior. We look at what is actually
-    on disk rather than at NOPTMAX, because PESTPP-IES can stop early.
+    The posterior is taken from the last iteration that PESTPP-IES actually
+    finished, which is not necessarily NOPTMAX - see `_ies_iterations()`.
 
     Args:
         m_d (`str`): the PESTPP-IES master directory
@@ -975,25 +1007,23 @@ def load_ies_obs_ensembles(m_d, case='freyberg'):
     Returns:
         tuple containing the prior and posterior observation ensembles
     """
-    iters = []
-    for f in os.listdir(m_d):
-        if f.startswith(case + '.') and f.endswith('.obs.csv'):
-            i = f.split('.')[-3]
-            if i.isdigit():
-                iters.append(int(i))
-    assert len(iters) > 0, f'no {case}.*.obs.csv files found in {m_d}'
-    # if only iteration 0 is there then PESTPP-IES never did an update, so there
-    # is no posterior to compare the prior against. Say so, rather than handing
-    # back the same ensemble twice and letting it look like nothing happened
-    assert max(iters) > 0, \
-        f'only found {case}.0.obs.csv in {m_d}, so there is no posterior yet. ' + \
-        'Was NOPTMAX zero or negative?'
-    print(f'prior is iteration {min(iters)}, posterior is iteration {max(iters)}')
-    ensembles = [pd.read_csv(os.path.join(m_d, f'{case}.{i}.obs.csv'), index_col=0)
-                 for i in [min(iters), max(iters)]]
-    # PESTPP-IES sometimes writes observation names in upper case
-    ensembles = [oe.rename(columns=str.lower) for oe in ensembles]
-    return ensembles[0], ensembles[1]
+    return _load_ies_ensembles(m_d, case, 'obs')
+
+
+def load_ies_par_ensembles(m_d, case='freyberg'):
+    """load the prior and posterior parameter ensembles written by PESTPP-IES.
+
+    The parameter-side twin of `load_ies_obs_ensembles()`, and it picks the
+    iterations the same way - from what is on disk, not from NOPTMAX.
+
+    Args:
+        m_d (`str`): the PESTPP-IES master directory
+        case (`str`): the control file name, without the .pst extension
+
+    Returns:
+        tuple containing the prior and posterior parameter ensembles
+    """
+    return _load_ies_ensembles(m_d, case, 'par')
 
 
 def plot_1to1_ensemble(pst, prior=None, posterior=None, title=None):

--- a/tutorials/part1_13_basic_ies/freyberg_ies.ipynb
+++ b/tutorials/part1_13_basic_ies/freyberg_ies.ipynb
@@ -428,7 +428,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ptpe = pd.read_csv(os.path.join(m_d,pst_name.replace(\".pst\",\".1.par.csv\")),index_col=0)\n",
+    "# the posterior parameter ensemble, from whichever iteration PESTPP-IES finished on\n",
+    "_, ptpe = hbd.load_ies_par_ensembles(m_d, case=pst_name.replace(\".pst\", \"\"))\n",
     "hbd.plot_ensemble_arr(ptpe.loc[:,parnmes],m_d,10)"
    ]
   },
@@ -593,7 +594,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ptpe = pd.read_csv(os.path.join(m_d,pst_name.replace(\".pst\",\".{0}.par.csv\".format(pst.control_data.noptmax))),index_col=0)\n",
+    "# same again - read the last iteration on disk rather than assuming NOPTMAX,\n",
+    "# which would break if PESTPP-IES stopped early\n",
+    "_, ptpe = hbd.load_ies_par_ensembles(m_d, case=pst_name.replace(\".pst\", \"\"))\n",
     "hbd.plot_ensemble_arr(ptpe.loc[:,parnmes],m_d,10)"
    ]
   },

--- a/tutorials/part1_14_dsi/freyberg_dsi.ipynb
+++ b/tutorials/part1_14_dsi/freyberg_dsi.ipynb
@@ -195,24 +195,35 @@
     "# a negative head is unambiguous garbage - there is no reading of this model in\n",
     "# which a water level is -1e15 m\n",
     "negative = (oe[head_obs] < 0).any(axis=1)\n",
-    "print(f'realisations with a negative head: {negative.sum()}')\n",
-    "\n",
-    "# the high end is less clear cut. Heads at the observation wells sit around\n",
-    "# 30-40 m, but the ensemble tails off smoothly - there is no obvious break\n",
-    "print('\\nper-realisation maximum head, quantiles:')\n",
-    "print(oe[head_obs].max(axis=1).quantile([0.5,0.9,0.95,0.99,1.0]).round(1).to_string())\n",
+    "print(f'realisations with a negative head: {negative.sum()} of {oe.shape[0]}')\n",
     "\n",
     "# which sites go bad, and how badly\n",
     "worst = oe[head_obs].min().sort_values()\n",
     "print('\\nworst five outputs (minimum value over the ensemble):')\n",
-    "print(worst.head(5).to_string())"
+    "print(worst.head(5).to_string())\n",
+    "\n",
+    "# the high end is less clear cut - plot it and see. Sorted, so we are looking for\n",
+    "# a step: somewhere the sensible realisations stop and the broken ones start\n",
+    "max_head = oe[head_obs].max(axis=1).sort_values().values\n",
+    "fig, ax = plt.subplots(1, 1, figsize=(7, 4))\n",
+    "ax.plot(range(len(max_head)), max_head, 'b.', ms=5)\n",
+    "ax.axhline(100, color='r', ls='--', lw=1.5, label='100 m - the cut we are about to make')\n",
+    "ax.axhspan(20, 50, color='g', alpha=0.12, label='plausible water levels here')\n",
+    "ax.set_yscale('log')\n",
+    "ax.set_xlabel('realisation (sorted)')\n",
+    "ax.set_ylabel('highest simulated head in that realisation (m, log scale)')\n",
+    "ax.set_title('Is there an obvious line between good and broken?')\n",
+    "ax.legend(fontsize=8)\n",
+    "plt.tight_layout();"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now the part that matters. Is any of this contaminating something we care about?"
+    "No, there isn't. The negative heads are unarguable, but above them the ensemble just tails off smoothly out of the plausible band and keeps going - there is no step, no gap, nowhere the data tells us to draw the line. We will have to choose one, and own it.\n",
+    "\n",
+    "First though, the part that matters most. Is any of this contaminating something we actually care about?"
    ]
   },
   {
@@ -284,7 +295,7 @@
    "outputs": [],
    "source": [
     "# drop the unambiguous failures, plus realisations whose heads climb implausibly\n",
-    "# high. The 100 m cut is OUR CHOICE - there is no break in the data to guide us,\n",
+    "# high. The 100 m cut is OUR CHOICE - the plot above shows no break to guide us,\n",
     "# so this is a judgement about what is physically plausible. Change it and see\n",
     "MAX_PLAUSIBLE_HEAD = 100.0\n",
     "blown_up = negative | (oe[head_obs] > MAX_PLAUSIBLE_HEAD).any(axis=1)\n",
@@ -294,9 +305,22 @@
     "print(f'head range now: {data[head_obs].values.min():.2f} to {data[head_obs].values.max():.2f} m')\n",
     "\n",
     "ce = cumulative_energy(data)\n",
-    "print('\\ncomponents needed, after screening:')\n",
-    "for t in [0.9, 0.99, 0.999]:\n",
-    "    print(f'  {t*100:5.1f}% of variance -> {n_components_for(ce, t)} component(s)')"
+    "\n",
+    "# how many components does it take to describe the ensemble, before and after?\n",
+    "fig, ax = plt.subplots(1, 1, figsize=(6.5, 4))\n",
+    "ax.plot(np.arange(1, len(ce_raw)+1), ce_raw, 'r-', label='raw ensemble')\n",
+    "ax.plot(np.arange(1, len(ce)+1), ce, 'b-', label='after screening')\n",
+    "ax.axhline(0.99, color='k', ls='--', lw=1.0, label='99% of variance')\n",
+    "ax.set_xlim(0, 40)\n",
+    "ax.set_xlabel('number of principal components')\n",
+    "ax.set_ylabel('cumulative share of variance')\n",
+    "ax.set_title('One bad realisation makes the problem look\\none-dimensional when it is not')\n",
+    "ax.legend(fontsize=9)\n",
+    "plt.tight_layout()\n",
+    "\n",
+    "print(f'\\ncomponents needed for 99% of the variance:'\n",
+    "      f'\\n  raw            : {n_components_for(ce_raw, 0.99)}'\n",
+    "      f'\\n  after screening: {n_components_for(ce, 0.99)}')"
    ]
   },
   {
@@ -327,17 +351,31 @@
     "    names = [n for n in names if n in data.columns]\n",
     "    if len(names) == 0:\n",
     "        continue\n",
-    "    rows.append((grp, len(names), data[names].var().sum()))\n",
-    "vardf = pd.DataFrame(rows, columns=['group','nobs','total_variance'])\n",
-    "vardf['share_%'] = 100 * vardf.total_variance / vardf.total_variance.sum()\n",
-    "vardf.sort_values('share_%', ascending=False).round(2)"
+    "    rows.append((grp, data[names].var().sum()))\n",
+    "vardf = pd.DataFrame(rows, columns=['group','total_variance'])\n",
+    "vardf['share'] = 100 * vardf.total_variance / vardf.total_variance.sum()\n",
+    "vardf = vardf.sort_values('total_variance')\n",
+    "\n",
+    "# head sites in blue so they are easy to pick out from the fluxes\n",
+    "colors = ['b' if g.startswith('trgw') else '0.5' for g in vardf.group]\n",
+    "\n",
+    "fig, ax = plt.subplots(1, 1, figsize=(7, 5))\n",
+    "ax.barh(vardf.group, vardf.total_variance, color=colors)\n",
+    "ax.set_xscale('log')\n",
+    "ax.set_xlabel('total variance across the training ensemble (log scale)')\n",
+    "ax.set_title('Where the ensemble variance lives\\n(blue = head observation sites)')\n",
+    "# label the ones that actually matter\n",
+    "for y, (v, sh) in enumerate(zip(vardf.total_variance, vardf.share)):\n",
+    "    if sh >= 1.0:\n",
+    "        ax.text(v*1.5, y, f'{sh:.0f}%', va='center', fontsize=9)\n",
+    "plt.tight_layout();"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Streamflow and particle travel time carry essentially all of it. Every head site rounds to **0.0%** - and heads are half of the observations we are actually fitting.\n",
+    "Note the log scale - that plot spans five orders of magnitude. Streamflow, travel time and the two exchange fluxes carry essentially all of the variance. Every head site is down at the far left, contributing a fraction of a percent between them - and heads are half of the observations we are actually fitting.\n",
     "\n",
     "This is not because heads are uninformative. It is because an SVD ranks directions by *absolute* variance and has no idea that one column is in metres and another is in cubic metres per day. Head variance across this ensemble is around $10^3$; streamflow variance is around $10^8$. The components will describe streamflow and ignore heads, whatever we do with weights later.\n",
     "\n",
@@ -1072,30 +1110,38 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# nested subsets of the training data. Guard the list so this still runs when the\n",
-    "# training ensemble is small (e.g. a cut-down CI run)\n",
-    "ne_list = sorted({n for n in [25, 50, 100, data.shape[0]] if 10 <= n <= data.shape[0]})\n",
-    "print('training ensemble sizes to compare:', ne_list)\n",
+    "# Averaging over several random subsets per size, because a single subset is a\n",
+    "# coin toss - we want the trend, not one draw. The full ensemble has only one\n",
+    "# possible subset, so it needs no repeats.\n",
+    "N_REPS = 4\n",
+    "rng = np.random.default_rng(1234)\n",
     "\n",
-    "results = []\n",
+    "n_full = data.shape[0]\n",
+    "ne_list = sorted({n for n in [25, 50, 100, n_full] if 10 <= n <= n_full})\n",
+    "print(f'training ensemble sizes: {ne_list}, with up to {N_REPS} random subsets each')\n",
+    "\n",
+    "rows = []\n",
     "for ne in ne_list:\n",
-    "    subset = data.iloc[:ne, :]\n",
-    "    _, m_d_ne = build_and_condition(subset, transforms, f'ne{ne}')\n",
-    "    p_ne = pyemu.Pst(os.path.join(m_d_ne,'dsi.pst'))\n",
-    "    pr_ne, pt_ne = hbd.load_ies_obs_ensembles(m_d_ne, case='dsi')\n",
-    "    for fore in p_ne.forecast_names:\n",
-    "        truth = p_ne.observation_data.loc[fore,'obsval']\n",
-    "        results.append({'Ne': ne, 'forecast': fore,\n",
-    "                        'posterior_sd': pt_ne[fore].std(),\n",
-    "                        'brackets_truth': bool(pt_ne[fore].min() <= truth <= pt_ne[fore].max())})\n",
-    "results = pd.DataFrame(results)"
+    "    for rep in range(1 if ne == n_full else N_REPS):\n",
+    "        idx = data.index if ne == n_full else rng.choice(data.index, size=ne, replace=False)\n",
+    "        _, m_d_ne = build_and_condition(data.loc[idx, :], transforms, f'ne{ne}r{rep}')\n",
+    "        p_ne = pyemu.Pst(os.path.join(m_d_ne,'dsi.pst'))\n",
+    "        _, pt_ne = hbd.load_ies_obs_ensembles(m_d_ne, case='dsi')\n",
+    "        for fore in p_ne.forecast_names:\n",
+    "            truth = p_ne.observation_data.loc[fore,'obsval']\n",
+    "            rows.append({'Ne': ne, 'rep': rep, 'forecast': fore,\n",
+    "                         'posterior_sd': pt_ne[fore].std(),\n",
+    "                         'brackets_truth': bool(pt_ne[fore].min() <= truth <= pt_ne[fore].max())})\n",
+    "sweep = pd.DataFrame(rows)\n",
+    "print(f'\\n{len(sweep)//len(ne_list)} forecast results per size, '\n",
+    "      f'{sweep.rep.nunique()} repeats at the smaller sizes')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Two things to look at. First, how wide is the posterior forecast distribution?"
+    "Two things to look at, side by side. On the left, how wide is the posterior forecast distribution - expressed relative to the full-ensemble result, so that forecasts in completely different units can share an axis. On the right, how often does that posterior actually contain the true value."
    ]
   },
   {
@@ -1104,16 +1150,44 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results.pivot_table(index='forecast', columns='Ne', values='posterior_sd').round(1)"
+    "# spread relative to the full-ensemble answer, so all four forecasts fit on one axis\n",
+    "reference = sweep.loc[sweep.Ne == n_full].groupby('forecast').posterior_sd.mean()\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(11, 4.2))\n",
+    "\n",
+    "for fore, grp in sweep.groupby('forecast'):\n",
+    "    sd = grp.groupby('Ne').posterior_sd\n",
+    "    mean, lo, hi = sd.mean()/reference[fore], sd.min()/reference[fore], sd.max()/reference[fore]\n",
+    "    line, = axes[0].plot(mean.index, mean.values, 'o-', label=fore)\n",
+    "    # the band is the spread over random subsets - i.e. how much luck was involved\n",
+    "    axes[0].fill_between(mean.index, lo.values, hi.values, alpha=0.15, color=line.get_color())\n",
+    "\n",
+    "    cov = grp.groupby('Ne').brackets_truth.mean()\n",
+    "    axes[1].plot(cov.index, cov.values, 'o-', label=fore, color=line.get_color())\n",
+    "\n",
+    "axes[0].axhline(1.0, color='k', ls='--', lw=1.0)\n",
+    "axes[0].set_xlabel('training ensemble size $N_e$')\n",
+    "axes[0].set_ylabel('posterior spread,\\nrelative to the full ensemble')\n",
+    "axes[0].set_title('Sample less, and the posterior\\ngets NARROWER')\n",
+    "axes[0].legend(fontsize=8)\n",
+    "\n",
+    "axes[1].axhline(1.0, color='k', ls='--', lw=1.0)\n",
+    "axes[1].set_ylim(-0.05, 1.1)\n",
+    "axes[1].set_xlabel('training ensemble size $N_e$')\n",
+    "axes[1].set_ylabel('fraction of repeats whose\\nposterior contains the truth')\n",
+    "axes[1].set_title('...and stops containing\\nthe truth')\n",
+    "axes[1].legend(fontsize=8)\n",
+    "\n",
+    "plt.tight_layout();"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The posterior gets **narrower as the training ensemble gets smaller**. That is the opposite of what should happen. Less information ought to mean more uncertainty, but an undersampled covariance matrix cannot see variability it never sampled, so the emulator mistakes a small sample for a well-constrained answer. This is ensemble collapse by undersampling, and it is dangerous precisely because it looks like success.\n",
+    "The left panel is the one to sit with. **The posterior gets narrower as the training ensemble gets smaller** - every line drops below the dashed reference as you move left. That is backwards. Less information ought to mean *more* uncertainty. But an undersampled covariance matrix cannot see variability it never sampled, so the emulator mistakes a small sample for a well-constrained answer. This is ensemble collapse by undersampling, and it is dangerous precisely because it looks like success: a tight posterior is what we are all hoping for.\n",
     "\n",
-    "Second, and this is the part that matters for a decision - does the posterior still contain the truth?"
+    "The shaded bands are the spread over random subsets of the same size, so they tell you how much of your answer was luck rather than information. They tend to widen as $N_e$ shrinks - for `part_time` the spread between the best and worst subset of 25 is larger than the mean itself. Which subset of 25 runs you happened to have would materially change what you reported."
    ]
   },
   {
@@ -1122,16 +1196,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results.pivot_table(index='forecast', columns='Ne', values='brackets_truth', aggfunc='first')"
+    "# how far does the posterior have to stretch to reach the truth?\n",
+    "fig, axes = plt.subplots(1, len(reference), figsize=(3.4*len(reference), 3.2), squeeze=False)\n",
+    "for ax, fore in zip(axes[0,:], sorted(reference.index)):\n",
+    "    grp = sweep.loc[sweep.forecast == fore]\n",
+    "    truth = pst_tx.observation_data.loc[fore,'obsval']\n",
+    "    for ne, g in grp.groupby('Ne'):\n",
+    "        ax.scatter([ne]*len(g), g.posterior_sd, s=25,\n",
+    "                   c=['b' if b else 'r' for b in g.brackets_truth])\n",
+    "    ax.set_title(fore, fontsize=10)\n",
+    "    ax.set_xlabel('$N_e$')\n",
+    "    ax.set_ylabel('posterior sd')\n",
+    "axes[0,0].scatter([],[],c='b',label='contains truth')\n",
+    "axes[0,0].scatter([],[],c='r',label='misses truth')\n",
+    "axes[0,0].legend(fontsize=8)\n",
+    "fig.suptitle('Every run, coloured by whether its posterior contains the true value', y=1.04)\n",
+    "plt.tight_layout();"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "With the full ensemble, every forecast posterior brackets its true value. Shrink the training set and `part_time` stops doing so - the small-ensemble answer is both narrower *and* wrong. A modeller who could only afford 25 runs would have reported a confident travel-time forecast that excludes reality, with nothing in the output to suggest a problem.\n",
+    "Every individual run is on that last figure, red where its posterior missed the truth. The pattern is the point: the misses cluster at small $N_e$, and they are the runs with the *smallest* posterior spread. Narrow and wrong, together.\n",
     "\n",
-    "That is the curse of dimensionality in one table, and it is worth being blunt about how it scales. This toy problem has 68 parameters and we could afford 225 runs, so we are comfortable. A real model might carry $10^4$-$10^6$ parameters and afford a few hundred runs. The arithmetic does not improve: you are always describing a very high-dimensional object with however many directions your run budget bought, and **there is no diagnostic in a DSI run that tells you when you have crossed from \"enough\" to \"not enough\"**. The posterior looks equally confident either way.\n",
+    "A modeller who could only afford 25 runs would have reported a confident travel-time forecast that excludes reality, with nothing in the output to suggest a problem.\n",
+    "\n",
+    "That is the curse of dimensionality, and it is worth being blunt about how it scales. This toy problem has 68 parameters and we could afford 225 runs, so we are comfortable. A real model might carry $10^4$-$10^6$ parameters and afford a few hundred runs. The arithmetic does not improve: you are always describing a very high-dimensional object with however many directions your run budget bought, and **there is no diagnostic in a DSI run that tells you when you have crossed from \"enough\" to \"not enough\"**. The posterior looks equally confident either way.\n",
     "\n",
     "Practical consequences, none of them exotic:\n",
     "\n",

--- a/tutorials/part1_14_dsi/freyberg_dsi.ipynb
+++ b/tutorials/part1_14_dsi/freyberg_dsi.ipynb
@@ -12,9 +12,9 @@
     "\n",
     "The consequence is the interesting bit: **DSI needs no new model runs at all.** We already have a prior Monte Carlo ensemble from the iES notebook. That ensemble is all DSI needs.\n",
     "\n",
-    "The trade is just as blunt: we give up parameters. A DSI posterior tells you about forecasts. It cannot tell you what hydraulic conductivity field produced them, because it never had one.\n",
+    "The catch is not what people usually assume. It is not that you lose access to parameters - you can carry those along too, and we will. It is that the emulator is a *model of the model*: an approximation built from a finite number of runs, and it can only ever be as good as that sample allows. We will get to what that costs.\n",
     "\n",
-    "See the original paper [Sun and Durlofsky (2017)](https://doi.org/10.1007/s11004-016-9672-8) and later variants (e.g. [Lima et al 2020](https://doi.org/10.1007/s10596-020-09933-w)). There are also [GMDSI webinars on YouTube](https://www.youtube.com/watch?v=s2g3HaJa1Wk&t=1564s). The [part2 DSI notebook](../part2_10_eva_and_dsi/2_freyberg_ensemble_data_space_inversion.ipynb) goes deeper, on a much higher-dimensional problem."
+    "This notebook follows the same maths and notation as the [intro to EVA and DSI](../part0_intro_to_eva_and_dsi/intro_to_eva_and_dsi.ipynb) notebook in part0, which works through it on a tiny made-up dataset - a good place to start if the algebra below moves too fast. The original paper is [Sun and Durlofsky (2017)](https://doi.org/10.1007/s11004-016-9672-8), with later variants in e.g. [Lima et al (2020)](https://doi.org/10.1007/s10596-020-09933-w). There are also [GMDSI webinars on YouTube](https://www.youtube.com/watch?v=s2g3HaJa1Wk&t=1564s). The [part2 DSI notebook](../part2_10_eva_and_dsi/2_freyberg_ensemble_data_space_inversion.ipynb) does all of this on a much higher-dimensional problem."
    ]
   },
   {
@@ -23,30 +23,35 @@
    "source": [
     "## How DSI works, briefly\n",
     "\n",
-    "Write $\\mathbf{d}$ for the vector of *all* model outputs - the ones we have measurements for and the forecasts, stacked together. A prior Monte Carlo run gives us $N_e$ realisations of it. Centre them and scale by $\\sqrt{N_e-1}$:\n",
+    "Notation follows the part0 [intro to EVA and DSI](../part0_intro_to_eva_and_dsi/intro_to_eva_and_dsi.ipynb) notebook, and after it [Lima et al (2020)](https://doi.org/10.1007/s10596-020-09933-w).\n",
     "\n",
-    "$$\\Delta\\mathbf{D} = \\frac{1}{\\sqrt{N_e-1}}\\left[\\mathbf{d}_1-\\bar{\\mathbf{d}},\\;\\dots,\\;\\mathbf{d}_{N_e}-\\bar{\\mathbf{d}}\\right]$$\n",
+    "Write $\\mathbf{d}$ for the vector of *all* model outputs - those corresponding to our measurements and those corresponding to our forecasts, stacked together. A prior Monte Carlo run gives us $N_e$ realisations of it. Its covariance is\n",
     "\n",
-    "so that $\\mathbf{C}_{dd} = \\Delta\\mathbf{D}\\,\\Delta\\mathbf{D}^T$ is the sample covariance of the outputs - the thing that encodes how every output co-varies with every other, including how the measured quantities co-vary with the forecasts. Take its SVD, $\\Delta\\mathbf{D} = \\mathbf{U}\\mathbf{S}\\mathbf{V}^T$.\n",
+    "$$\\mathbf{C}_d = \\Delta\\mathbf{D}\\,\\Delta\\mathbf{D}^T, \\qquad \\Delta\\mathbf{D} = \\frac{1}{\\sqrt{N_e-1}}\\left[\\mathbf{d}_1-\\bar{\\mathbf{d}},\\;\\dots,\\;\\mathbf{d}_{N_e}-\\bar{\\mathbf{d}}\\right]$$\n",
+    "\n",
+    "where $\\Delta\\mathbf{D}$ is the deviations matrix and $\\bar{\\mathbf{d}}$ the ensemble mean. $\\mathbf{C}_d$ is the object that matters: it encodes how every output co-varies with every other - crucially, how the measured quantities co-vary with the forecasts.\n",
+    "\n",
+    "Take the SVD of the deviations matrix, $\\Delta\\mathbf{D} = \\mathbf{U}\\boldsymbol{\\Sigma}\\mathbf{V}^T$, which gives us a square root of the covariance:\n",
+    "\n",
+    "$$\\mathbf{C}_d^{1/2} = \\mathbf{U}\\boldsymbol{\\Sigma}$$\n",
     "\n",
     "Now the trick. Instead of parameterising the *model*, DSI parameterises the *outputs*:\n",
     "\n",
-    "$$\\mathbf{d}(\\boldsymbol{\\xi}) = \\bar{\\mathbf{d}} + \\mathbf{U}\\mathbf{S}\\,\\boldsymbol{\\xi}$$\n",
+    "$$\\mathbf{d}_{\\text{PCA}} = \\bar{\\mathbf{d}} + \\mathbf{C}_d^{1/2}\\,\\mathbf{x}$$\n",
     "\n",
-    "That is the entire emulator. Feed it a vector $\\boldsymbol{\\xi}$ of latent coefficients, get back a complete set of model outputs.\n",
+    "That is the entire emulator. Feed it a vector $\\mathbf{x}$, get back a complete set of model outputs. Why is that sensible? Because if $\\mathbf{x}\\sim N(\\mathbf{0},\\mathbf{I})$ then\n",
     "\n",
-    "Why is that a sensible thing to do? Because if we give $\\boldsymbol{\\xi}$ a standard normal prior, $\\boldsymbol{\\xi}\\sim N(\\mathbf{0},\\mathbf{I})$, then\n",
+    "$$\\mathrm{Cov}\\left[\\mathbf{C}_d^{1/2}\\mathbf{x}\\right] = \\mathbf{U}\\boldsymbol{\\Sigma}\\,\\mathbf{I}\\,\\boldsymbol{\\Sigma}^T\\mathbf{U}^T = \\mathbf{U}\\boldsymbol{\\Sigma}^2\\mathbf{U}^T = \\mathbf{C}_d$$\n",
     "\n",
-    "$$\\mathrm{Cov}\\left[\\mathbf{U}\\mathbf{S}\\boldsymbol{\\xi}\\right] = \\mathbf{U}\\mathbf{S}\\,\\mathbf{I}\\,\\mathbf{S}^T\\mathbf{U}^T = \\mathbf{U}\\mathbf{S}^2\\mathbf{U}^T = \\mathbf{C}_{dd}$$\n",
+    "The emulator reproduces the prior covariance of the model outputs *exactly*. That is why the elements of $\\mathbf{x}$ - the \"latent-space parameters\" - get a mean of zero and a standard deviation of one, and it is literally what `prepare_pestpp` writes into `dsi.unc` for us later.\n",
     "\n",
-    "The emulator reproduces the prior covariance of the model outputs *exactly*. That is why the latent parameters get a mean of zero and a standard deviation of one - and it is literally what `prepare_pestpp` writes into `dsi.unc` for us later.\n",
+    "History matching is then: find the $\\mathbf{x}$ whose measured-quantity entries match our observations. Because $\\mathbf{x}\\mapsto\\mathbf{d}$ is **linear** and the prior on $\\mathbf{x}$ is **Gaussian**, this is the linear-Gaussian Bayesian problem - the same one FOSM solves, but posed in output space instead of parameter space. `pestpp-ies` solves it iteratively, which also copes with the mild nonlinearity that transformations introduce later.\n",
     "\n",
-    "History matching is then: find the $\\boldsymbol{\\xi}$ values whose measured-quantity entries match our observations. Because $\\boldsymbol{\\xi}\\mapsto\\mathbf{d}$ is **linear** and the prior on $\\boldsymbol{\\xi}$ is **Gaussian**, this is the linear-Gaussian Bayesian problem - the same one FOSM solves, but posed in output space instead of parameter space. `pestpp-ies` solves it iteratively, and because it is iterative it copes with the mild nonlinearity that transformations introduce (more on those later).\n",
+    "Three things to notice, because all three come back:\n",
     "\n",
-    "Two things to notice, because both come back to bite us:\n",
-    "\n",
-    "1. The model appears nowhere in that equation. Once $\\mathbf{U}$ and $\\mathbf{S}$ are computed, MODFLOW is done.\n",
-    "2. Everything rests on $\\mathbf{C}_{dd}$ - a mean and a covariance. Those two moments pin down a distribution **only if that distribution is Gaussian**. Hold that thought."
+    "1. The model appears nowhere in that equation. Once $\\mathbf{U}$ and $\\boldsymbol{\\Sigma}$ are computed, MODFLOW is done.\n",
+    "2. Everything rests on $\\mathbf{C}_d$ - a mean and a covariance. Those two moments pin down a distribution **only if that distribution is Gaussian**.\n",
+    "3. $\\Delta\\mathbf{D}$ has $N_e$ columns, so $\\mathbf{C}_d^{1/2}$ has at most $N_e$ useful columns however long $\\mathbf{d}$ is. The emulator can only ever represent $N_e$ independent directions of variability. Remember this one."
    ]
   },
   {
@@ -403,7 +408,7 @@
    "source": [
     "## What are the parameters now?\n",
     "\n",
-    "This is the conceptual jump. Our model had 68 adjustable parameters: pilot point hydraulic conductivities and recharge. The emulator has none of them. Its \"parameters\" are the **latent coefficients** - the weights on each principal component of the output ensemble.\n",
+    "This is the conceptual jump. Our model had 68 adjustable parameters: pilot point hydraulic conductivities and recharge. The emulator has none of them. Its parameters are the elements of $\\mathbf{x}$ - coefficients on the principal components of the output ensemble. Following the part0 notebook, you can think of them as a mapping from the model's base parameters onto \"super parameters\" that drive the surrogate.\n",
     "\n",
     "To run the emulator, hand it a vector of those coefficients. That is the entire forward run:"
    ]
@@ -429,7 +434,11 @@
    "source": [
     "No MODFLOW. No files. A matrix multiply.\n",
     "\n",
-    "Notice what this buys and what it costs. Any vector of coefficients gives you a complete, self-consistent set of model outputs - heads, flows, travel time, historic and forecast - in microseconds. But there is no hydraulic conductivity field anywhere in that answer, and no way to get one back out."
+    "Any vector of coefficients gives you a complete, self-consistent set of model outputs - heads, flows, travel time, historic and forecast - in microseconds.\n",
+    "\n",
+    "A common thing to say at this point is that DSI has cost us access to parameters, so we can never ask what hydraulic conductivity field produced a given forecast. That is not true, and it is worth being clear about. Nothing in $\\bar{\\mathbf{d}} + \\mathbf{C}_d^{1/2}\\mathbf{x}$ cares what the entries of $\\mathbf{d}$ *mean* - they are just numbers that co-vary. So we can stack the model's parameters onto the output vector and DSI will learn their covariance along with everything else, and hand us their posterior too. We will do exactly that later in this notebook.\n",
+    "\n",
+    "The real constraint is point 3 from the maths section: $N_e$ directions of variability, no matter how many rows $\\mathbf{d}$ has. That is a much more interesting problem, and we come back to it once we have a working emulator."
    ]
   },
   {
@@ -497,11 +506,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Guard against extrapolation\n",
+    "### Prior data conflict, and extrapolation\n",
     "\n",
-    "An emulator interpolates between the runs it was trained on. Ask it to extrapolate and it will answer confidently and wrongly.\n",
+    "Ask an emulator about a part of output space its training runs never visited and it will answer. It will not warn you, and it will not widen its uncertainty. The maths puts no bound on $\\mathbf{x}$, so $\\bar{\\mathbf{d}} + \\mathbf{C}_d^{1/2}\\mathbf{x}$ can be pushed anywhere in the span of $\\mathbf{C}_d^{1/2}$ - well outside anything the model actually produced. Extrapolation is not impossible; it is *unconstrained*. You get a confidently wrong answer, delivered with the same narrow posterior as a well-supported one. (We will see a vivid example of this shortly.)\n",
     "\n",
-    "The specific way this bites in DSI is *prior data conflict*: an observation whose measured value lies outside the range the training ensemble ever produced. There is no combination of latent coefficients that will reach it, so `pestpp-ies` will contort the whole ensemble trying. Better to detect those observations and drop them, which is what `ies_drop_conflicts` does. Turn it on - for DSI it should be the default."
+    "The version of this that PEST++ can actually detect is *prior data conflict*: a measured value lying outside the range the training ensemble ever produced for that quantity. There is no $\\mathbf{x}$ that reaches it, so `pestpp-ies` will contort the whole ensemble trying. Better to spot those observations and drop them - which is what `ies_drop_conflicts` does. Turn it on; for DSI it should be the default.\n",
+    "\n",
+    "Treat a conflict as information, not a nuisance. It is telling you the prior ensemble does not span reality, and the honest fix is more or better model runs, not a louder emulator."
    ]
   },
   {
@@ -697,11 +708,11 @@
     "\n",
     "Go back to the emulator equation:\n",
     "\n",
-    "$$\\mathbf{d}(\\boldsymbol{\\xi}) = \\bar{\\mathbf{d}} + \\mathbf{U}\\mathbf{S}\\,\\boldsymbol{\\xi}, \\qquad \\boldsymbol{\\xi}\\sim N(\\mathbf{0},\\mathbf{I})$$\n",
+    "$$\\mathbf{d}_{\\text{PCA}} = \\bar{\\mathbf{d}} + \\mathbf{C}_d^{1/2}\\,\\mathbf{x}, \\qquad \\mathbf{x}\\sim N(\\mathbf{0},\\mathbf{I})$$\n",
     "\n",
-    "We showed that this reproduces $\\mathbf{C}_{dd}$ exactly. What we glossed over is that a mean and a covariance **do not describe a distribution** - unless that distribution happens to be Gaussian. The multivariate normal is the one family that is completely determined by its first two moments. For anything else, matching the mean and covariance matches two summary statistics and throws the rest away.\n",
+    "We showed that this reproduces $\\mathbf{C}_d$ exactly. What we glossed over is that a mean and a covariance **do not describe a distribution** - unless that distribution happens to be Gaussian. The multivariate normal is the one family that is completely determined by its first two moments. For anything else, matching the mean and covariance matches two summary statistics and throws the rest away.\n",
     "\n",
-    "So what does DSI actually generate? A linear combination of Gaussian variables is Gaussian. Which means $\\mathbf{d}(\\boldsymbol{\\xi})$ is **multivariate normal, by construction** - regardless of what our prior ensemble looked like. If the outputs really were Gaussian, that is exact and free. If they were not, DSI has quietly replaced their distribution with the Gaussian that shares its mean and covariance.\n",
+    "So what does DSI actually generate? A linear combination of Gaussian variables is Gaussian. Which means $\\mathbf{d}_{\\text{PCA}}$ is **multivariate normal, by construction** - regardless of what our prior ensemble looked like. If the outputs really were Gaussian, that is exact and free. If they were not, DSI has quietly replaced their distribution with the Gaussian that shares its mean and covariance.\n",
     "\n",
     "That substitution has a specific and damaging consequence: **a Gaussian has infinite support in every direction.** It puts probability mass everywhere from $-\\infty$ to $+\\infty$. Nothing in the algebra knows that streamflow stops at zero, or that travel time does. So it strays past the bounds, and the negative flows above are exactly that happening.\n",
     "\n",
@@ -727,23 +738,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Strongly skewed, all of them - which is entirely normal for groundwater model outputs. Fluxes and travel times are bounded below and have long right tails; that is what they *are*.\n",
+    "Strongly skewed, all of them - which is entirely normal for groundwater model outputs. Fluxes and travel times are bounded, and have long tails; that is what they *are*.\n",
     "\n",
     "## Transformations: getting closer to normal\n",
     "\n",
-    "We cannot make the outputs Gaussian. But we can history match a *transformed* version of them that is much closer to Gaussian, and then map back. If $g$ is monotonic and invertible, doing DSI on $g(\\mathbf{d})$ and reporting $g^{-1}$ of the result is a legitimate change of variables - the SVD, the standard-normal prior and the linear-Gaussian update all happen in transformed space, where the assumption is much less of a lie.\n",
+    "We cannot make the outputs Gaussian. But we can history match a *transformed* version of them that is much closer to Gaussian, and then map back. If $g$ is monotonic and invertible, doing DSI on $g(\\mathbf{d})$ and reporting $g^{-1}$ of the result is a legitimate change of variables - the SVD, the standard-normal prior on $\\mathbf{x}$ and the linear-Gaussian update all happen in transformed space, where the assumption is much less of a lie.\n",
     "\n",
-    "Two transforms do most of the work, and they solve two different problems.\n",
+    "Two transforms do most of the work, and they address different problems.\n",
     "\n",
-    "**`log10` - for strictly positive, right-skewed quantities.** The log of a lognormal variable is *exactly* normal, and plenty of hydrologic quantities are roughly lognormal. It also fixes feasibility for free, and structurally rather than by luck: the inverse transform is $10^x$, which is positive for every real $x$. A log-transformed output *cannot* come back negative, no matter what the latent coefficients do.\n",
+    "**`log10` - for quantities you believe are log-distributed.** The log of a lognormal variable is *exactly* normal, and plenty of hydrologic quantities are roughly lognormal. pyemu's implementation is forgiving about the mechanics: if a column contains zeros or negatives it computes an offset automatically, shifts the data up, logs it, and subtracts the offset again on the way back. So it will never throw an error at you.\n",
     "\n",
-    "**`normal_score` - for anything at all.** Rank every value of an output within its own ensemble, then map that rank to the matching quantile of a standard normal. By construction the transformed marginal is *exactly* $N(0,1)$ - whatever shape it started with: skewed, bounded, bimodal, doesn't matter. The inverse maps back through the empirical distribution, so returned values stay inside (roughly) the range the training ensemble spanned. Feasibility again comes for free.\n",
+    "That forgiveness is precisely the trap. The transform runs whatever you feed it, but it is still *asserting* that the quantity is log-distributed. If that is wrong, you have not fixed the normality problem, you have replaced it with a different wrong assumption - silently. Note too that the positivity guarantee people reach for only holds when no offset was needed: with a shift applied, the inverse is $10^x - \\text{offset}$, which can return negative values again.\n",
     "\n",
-    "It also fixes the variance-scale problem we found earlier. Once every output has been mapped to $N(0,1)$, they all have unit variance, so no group can dominate the SVD by virtue of its units. Heads get a say again.\n",
+    "**`normal_score` - for anything at all.** Rank every value of an output within its own ensemble, then map that rank to the matching quantile of a standard normal. By construction the transformed marginal is *exactly* $N(0,1)$ - whatever shape it started with: skewed, bounded, bimodal, doesn't matter. No distributional assumption is being smuggled in. The inverse maps back through the empirical distribution, so returned values stay inside the range the training ensemble spanned, which gives physical feasibility for free. That same property is a limitation: it deliberately refuses to extrapolate, unless you ask it to with `quadratic_extrapolation=True`.\n",
     "\n",
-    "### But know what you are transforming\n",
+    "It also fixes the variance-scale problem we found earlier. Once every output has been mapped to $N(0,1)$ they all have unit variance, so no group can dominate the SVD by virtue of its units. Heads get a say again.\n",
     "\n",
-    "This is where it is easy to do real damage. \"Log the fluxes\" is wrong advice here, and the model will not warn you:"
+    "### So pick the transform for the physics, not for convenience\n",
+    "\n",
+    "Because `log10` will not complain, the burden is on us. Let's look at what these quantities actually are:"
    ]
   },
   {
@@ -762,11 +775,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- `part_time` is strictly positive. `log10` is a good fit.\n",
-    "- `gage-1` is non-negative but hits **exactly zero** - the river dries up in some realisations. $\\log_{10}(0)$ is undefined, so a plain log breaks. You would need an offset, or a different transform.\n",
-    "- `headwater` and `tailwater` are **negative most of the time**, and rightly so: they are groundwater/surface-water *exchange* fluxes, where the sign tells you which way the water goes. Log-transforming them is not a numerical inconvenience, it is a category error.\n",
+    "- `part_time` (particle travel time) is strictly positive, and a travel time plausibly *is* log-distributed - a mixture of path lengths and velocities multiplying together. `log10` is a defensible choice, and since no offset is needed here the inverse transform genuinely cannot return a negative travel time.\n",
+    "- `gage-1` (streamflow) is non-negative but hits **exactly zero** - the river dries up in some realisations. `log10` would apply an offset and carry on, but a distribution with an atom at zero is not lognormal, so we would be asserting something false.\n",
+    "- `headwater` and `tailwater` are **negative most of the time**, and rightly so: they are groundwater/surface-water *exchange* fluxes, where the sign tells you which way the water moves. Log-transforming a signed quantity is a category error, not a tuning choice. pyemu would shift and log it without a murmur.\n",
     "\n",
-    "So: `log10` on the travel time, `normal_score` on everything else. The transforms are applied in the order listed."
+    "So: `log10` on the travel time, `normal_score` on everything else. Transforms are applied in the order listed."
    ]
   },
   {
@@ -797,10 +810,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def build_and_condition(transforms, tag, noptmax=3):\n",
-    "    \"\"\"fit a DSI emulator, build a PEST interface for it, and condition it -\n",
-    "    exactly the steps we did by hand above\"\"\"\n",
-    "    dsi = DSI(pst=pst, data=data, transforms=transforms, energy_threshold=1.0)\n",
+    "def build_and_condition(training_data, transforms, tag, noptmax=3):\n",
+    "    \"\"\"fit a DSI emulator to `training_data`, build a PEST interface for it, and\n",
+    "    condition it - exactly the steps we did by hand above\"\"\"\n",
+    "    dsi = DSI(pst=pst, data=training_data, transforms=transforms, energy_threshold=1.0)\n",
     "    dsi.fit()\n",
     "\n",
     "    t_d = f'template_{tag}'\n",
@@ -808,7 +821,7 @@
     "    p.pestpp_options['forecasts'] = pst.pestpp_options['forecasts']\n",
     "    hbd.prep_bins(t_d)\n",
     "    p.pestpp_options['ies_drop_conflicts'] = True\n",
-    "    p.pestpp_options['ies_num_reals'] = data.shape[0]\n",
+    "    p.pestpp_options['ies_num_reals'] = training_data.shape[0]\n",
     "    p.control_data.noptmax = noptmax\n",
     "    p.write(os.path.join(t_d,'dsi.pst'), version=2)\n",
     "\n",
@@ -820,7 +833,7 @@
     "    return dsi, m_d\n",
     "\n",
     "\n",
-    "dsi_tx, m_d_tx = build_and_condition(transforms, 'tx')\n",
+    "dsi_tx, m_d_tx = build_and_condition(data, transforms, 'tx')\n",
     "pst_tx = pyemu.Pst(os.path.join(m_d_tx,'dsi.pst'))\n",
     "oe_pr_tx, oe_pt_tx = hbd.load_ies_obs_ensembles(m_d_tx, case='dsi')"
    ]
@@ -904,9 +917,15 @@
    "source": [
     "### How does that compare to iES?\n",
     "\n",
-    "DSI and iES are answering the same question from the same prior ensemble. iES did it by adjusting model parameters and re-running the model. DSI did it by adjusting latent coefficients and never touching the model. If they agree, that is a strong argument for using the cheap one.\n",
+    "Now a comparison, but we need to be careful about what it can and cannot tell us.\n",
     "\n",
-    "Let's put them side by side. The iES posterior is the last iteration of the second run in the previous notebook."
+    "The emulator is a **model of the model**. It was built entirely from Freyberg model runs, so it inherits every error the Freyberg model has - and adds approximation error of its own. It cannot be *more* right than the model it was trained on. If the model is wrong about how streamflow responds to recharge, the emulator will be wrong in the same way, and confidently so.\n",
+    "\n",
+    "So this is not a contest with a winner. The iES posterior from the previous notebook came from the full-order model - the thing the emulator is approximating. That makes iES the **reference**, and the question is one-directional:\n",
+    "\n",
+    "> does the emulator reproduce what the full-order model told us?\n",
+    "\n",
+    "Agreement means the emulator is doing its job and we can trust it for the price. Disagreement means the emulator is failing to capture something - or that the two runs used different ensemble sizes and we are looking at sampling noise. What disagreement never means is that DSI found a better answer than the model."
    ]
   },
   {
@@ -939,7 +958,187 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Have a good look at these. Where the two agree, DSI has given us the same answer for a tiny fraction of the compute. Where they disagree, the interesting question is *which one to believe* - and note that neither is automatically right. The two runs also used different ensemble sizes, so some of the difference is just sampling."
+    "Where the two agree, the emulator has faithfully reproduced a full-order-model result for a tiny fraction of the compute - which is the entire proposition, and on a real model it is a very large prize.\n",
+    "\n",
+    "Where they disagree, the emulator is the suspect. Bear in mind the two runs used different ensemble sizes (225 against 50), so some of the difference is sampling noise rather than emulator error. Neither of them is a check on whether the *Freyberg model* is right about anything - both inherit whatever it gets wrong, which is why the forecasts still miss the truth in places, exactly as they did in the iES and Monte Carlo notebooks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting the parameters back\n",
+    "\n",
+    "Earlier we promised to come back to this. The emulator equation does not care what the entries of $\\mathbf{d}$ represent - it learns a covariance between columns of numbers. So if we want the model's parameters in the posterior, we simply stack them onto the output vector and let DSI learn their covariance too.\n",
+    "\n",
+    "The prior parameter ensemble is sitting right next to the observation ensemble we have been using, in the same iES master directory, indexed by the same realisation names."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# the prior PARAMETER ensemble from the same iES run\n",
+    "pe = pd.read_csv(os.path.join(ies_d,'freyberg_pp.0.par.csv'),index_col=0)\n",
+    "pe.columns = [c.lower() for c in pe.columns]\n",
+    "pe = pe.astype(float)\n",
+    "\n",
+    "# stack the parameters onto the outputs, keeping only the realisations we screened\n",
+    "augmented = data.join(pe.loc[data.index, pst.adj_par_names], how='inner')\n",
+    "print(f'outputs only     : {data.shape}')\n",
+    "print(f'outputs + params : {augmented.shape}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Fit an emulator to that instead, and its forward run now returns parameters alongside the outputs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dsi_aug = DSI(pst=pst, data=augmented, energy_threshold=1.0)\n",
+    "dsi_aug.fit()\n",
+    "\n",
+    "sim = dsi_aug.predict(np.random.normal(0, 1, dsi_aug.s.shape))\n",
+    "print(f'the forward run now returns {sim.shape[0]} values, including parameters:')\n",
+    "print(sim.loc[['rch0','rch1']].to_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And `prepare_pestpp` carries them through as (zero-weight) observations, so a conditioned run gives you a posterior parameter ensemble - the same object iES would have given you, obtained without running the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pst_aug = dsi_aug.prepare_pestpp(t_d='template_aug', use_runstor=True)\n",
+    "print(f'observations in the augmented control file: {pst_aug.nobs}')\n",
+    "print(f'parameters carried through as observations : '\n",
+    "      f'{[p for p in pst.adj_par_names if p in pst_aug.obs_names][:4]} ...')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So \"DSI throws away the parameters\" is a choice, not a property of the method. Whether the *posterior* parameters it gives you are trustworthy is a separate question - they are only as good as the covariance the ensemble could estimate, which brings us to the actual problem.\n",
+    "\n",
+    "## The curse of dimensionality\n",
+    "\n",
+    "Look at what happened to the latent dimension when we added those 68 parameter columns:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'outputs only     : {data.shape[1]:3d} columns -> {dsi.s.shape[0]} latent parameters')\n",
+    "print(f'outputs + params : {augmented.shape[1]:3d} columns -> {dsi_aug.s.shape[0]} latent parameters')\n",
+    "print(f'realisations in the training data: {data.shape[0]}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Nothing. We added 68 columns and the emulator's latent dimension did not move, because it never depended on the number of columns in the first place. $\\Delta\\mathbf{D}$ has $N_e$ columns, so $\\mathbf{C}_d^{1/2}$ has at most $N_e$ useful ones - point 3 from the maths section, arriving.\n",
+    "\n",
+    "This is the whole difficulty, and it is not really about DSI. **We are estimating an $N_d \\times N_d$ covariance matrix from $N_e$ samples.** Here $N_d = 469$ and $N_e = 225$, so $\\mathbf{C}_d$ has 110,000 distinct entries estimated from 225 realisations. It is enormously rank-deficient, and the directions it *does* contain are estimated from a small sample, so some of the correlations in it are not real - they are sampling noise. (If that sounds familiar, it is exactly the problem localisation exists to fix in iES.)\n",
+    "\n",
+    "The uncomfortable part is that adding columns is free and adding realisations is not. Columns cost nothing - they are already-computed model outputs. Realisations cost a model run each. So the temptation on a real problem is always to describe more and sample less, which is precisely the wrong direction.\n",
+    "\n",
+    "Rather than assert what that costs, let's measure it: refit and re-condition the emulator using progressively smaller slices of the same training ensemble."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# nested subsets of the training data. Guard the list so this still runs when the\n",
+    "# training ensemble is small (e.g. a cut-down CI run)\n",
+    "ne_list = sorted({n for n in [25, 50, 100, data.shape[0]] if 10 <= n <= data.shape[0]})\n",
+    "print('training ensemble sizes to compare:', ne_list)\n",
+    "\n",
+    "results = []\n",
+    "for ne in ne_list:\n",
+    "    subset = data.iloc[:ne, :]\n",
+    "    _, m_d_ne = build_and_condition(subset, transforms, f'ne{ne}')\n",
+    "    p_ne = pyemu.Pst(os.path.join(m_d_ne,'dsi.pst'))\n",
+    "    pr_ne, pt_ne = hbd.load_ies_obs_ensembles(m_d_ne, case='dsi')\n",
+    "    for fore in p_ne.forecast_names:\n",
+    "        truth = p_ne.observation_data.loc[fore,'obsval']\n",
+    "        results.append({'Ne': ne, 'forecast': fore,\n",
+    "                        'posterior_sd': pt_ne[fore].std(),\n",
+    "                        'brackets_truth': bool(pt_ne[fore].min() <= truth <= pt_ne[fore].max())})\n",
+    "results = pd.DataFrame(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Two things to look at. First, how wide is the posterior forecast distribution?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results.pivot_table(index='forecast', columns='Ne', values='posterior_sd').round(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The posterior gets **narrower as the training ensemble gets smaller**. That is the opposite of what should happen. Less information ought to mean more uncertainty, but an undersampled covariance matrix cannot see variability it never sampled, so the emulator mistakes a small sample for a well-constrained answer. This is ensemble collapse by undersampling, and it is dangerous precisely because it looks like success.\n",
+    "\n",
+    "Second, and this is the part that matters for a decision - does the posterior still contain the truth?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results.pivot_table(index='forecast', columns='Ne', values='brackets_truth', aggfunc='first')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With the full ensemble, every forecast posterior brackets its true value. Shrink the training set and `part_time` stops doing so - the small-ensemble answer is both narrower *and* wrong. A modeller who could only afford 25 runs would have reported a confident travel-time forecast that excludes reality, with nothing in the output to suggest a problem.\n",
+    "\n",
+    "That is the curse of dimensionality in one table, and it is worth being blunt about how it scales. This toy problem has 68 parameters and we could afford 225 runs, so we are comfortable. A real model might carry $10^4$-$10^6$ parameters and afford a few hundred runs. The arithmetic does not improve: you are always describing a very high-dimensional object with however many directions your run budget bought, and **there is no diagnostic in a DSI run that tells you when you have crossed from \"enough\" to \"not enough\"**. The posterior looks equally confident either way.\n",
+    "\n",
+    "Practical consequences, none of them exotic:\n",
+    "\n",
+    "- Spend your budget on realisations, not on carrying more outputs. Extra columns are nearly free and buy little; extra realisations are expensive and buy the thing you actually need.\n",
+    "- Only carry the outputs you need. Part2's DSI notebook drops most of its observations before fitting for exactly this reason.\n",
+    "- Do the sweep above on your own problem. Halve the ensemble, refit, and see whether the forecasts move. If they do, you were not converged.\n",
+    "- Treat a suspiciously tight posterior as a symptom, not a result."
    ]
   },
   {
@@ -950,19 +1149,21 @@
     "\n",
     "DSI is fast, it is easy to run, and it is genuinely useful. It is not magic, and the ways it fails are not always loud. In rough order of how often they bite:\n",
     "\n",
-    "**1. It cannot go outside its training data.** The emulator is a weighted recombination of the ensemble it was fitted to. If no realisation ever produced a low enough streamflow, no combination of latent coefficients will produce one either. When the measured data sits outside that envelope you get prior data conflict - which is why `ies_drop_conflicts` should always be on, and why a conflict is a message about your prior, not a nuisance to be silenced. If you need to go somewhere the ensemble never went, the fix is more model runs, not a cleverer emulator.\n",
+    "**1. It is a model of the model.** The emulator is an approximation of the full-order model, built from a finite sample of its behaviour. Every error in the model is inherited intact, and approximation error is added on top. An emulator can be a faithful stand-in for a bad model - and it will be just as confident. Nothing in a DSI workflow tests whether your model is right.\n",
     "\n",
-    "**2. Garbage in, garbage out - and it is worse than usual.** We spent the first third of this notebook on this for good reason. Because DSI is built on variance, one blown-up realisation does not just add noise, it can consume the entire latent space. Always look at your training data before you fit.\n",
+    "**2. It will extrapolate, and it will be confidently wrong when it does.** Nothing bounds $\\mathbf{x}$, so the emulator can be pushed well outside the region its training runs explored, and it reports no extra uncertainty when that happens - we saw it invent negative streamflow. `normal_score` restricts this by construction, and `ies_drop_conflicts` catches the detectable case (measured values outside the ensemble range), but neither makes extrapolation safe. If you need to go somewhere the ensemble never went, the fix is more model runs.\n",
     "\n",
-    "**3. Untransformed, the whole thing rests on a normality assumption it does not meet.** This is the one we spent most of the notebook on. The reparameterisation reproduces a mean and a covariance, which describes a distribution only if it is Gaussian - and a Gaussian has infinite support, so the emulator cheerfully produced negative streamflow in 42% of realisations. On top of that, an SVD ranks directions by absolute variance and does not know metres from m³/d, so head observations contributed 0.0% of the components before we transformed. Transformations address both, and `normal_score` addresses them at the same time. They are not an optional refinement - treat an untransformed DSI run as a first sketch, not an answer. But pick them for what the quantity physically is: `log10` on a signed exchange flux is a category error, not a tuning choice. `rowwise_groups` is the other lever, scaling each observation group before the SVD.\n",
+    "**3. Garbage in, garbage out - and worse than usual.** Because DSI is built on variance, one blown-up realisation does not just add noise, it can consume the entire latent space. We spent the first third of this notebook on this for good reason. Always look at your training data before you fit.\n",
     "\n",
-    "**4. No parameters means no parameter insight.** You cannot ask a DSI posterior which part of the aquifer is transmissive, look at a posterior hydraulic conductivity field, or check whether a realisation is physically sensible. If your question is \"what is the forecast and how uncertain is it\", that is fine. If your question is \"why\", DSI cannot answer it.\n",
+    "**4. Untransformed, the normality assumption is not met and it shows.** The reparameterisation reproduces a mean and a covariance, which describes a distribution only if it is Gaussian - and a Gaussian has infinite support, so the emulator produced negative streamflow in 42% of realisations. Separately, an SVD ranks directions by absolute variance and does not know metres from m³/d, so head observations contributed 0.0% of the components until we transformed. Transforms address both. Treat an untransformed DSI run as a first sketch, and choose transforms for what the quantity physically is - `log10` will silently accept a signed flux and assume it is lognormal.\n",
     "\n",
-    "**5. Conditioning is linear-Gaussian in the latent space, and transforms only get you closer.** DSI assumes the relationship between observations and forecasts is captured by the covariance of the training ensemble. A normal-score transform makes each output's marginal exactly normal, but it does not make the joint distribution multivariate normal, so nonlinear dependence between observations and forecasts still gets smeared. One visible symptom is emulated time series that go saw-toothed in the forecast period - smooth where there is data to pin them down, jumping around where there is not. Part2 shows this clearly.\n",
+    "**5. Conditioning stays linear-Gaussian, even with transforms.** `normal_score` makes each output's *marginal* exactly normal; it does not make the *joint* distribution multivariate normal, which would need the dependence between outputs to be linear too. Nonlinear observation-forecast relationships still get smeared. A visible symptom is emulated time series going saw-toothed in the forecast period - smooth where data pins them down, jumping around where it does not. Part2 shows this clearly.\n",
     "\n",
-    "**6. It inherits every assumption in your prior.** DSI conditions the prior ensemble; it does not question it. If the prior parameterisation is too coarse - as we found out the hard way in the Monte Carlo and regularisation notebooks - DSI will hand you a posterior that is too narrow, with exactly the same confidence as a good one. It is not a way to escape a badly posed problem.\n",
+    "**6. Dimensionality is the real constraint** - see the section above. The emulator gets $N_e$ directions of variability and no more, however many parameters and outputs you stack into $\\mathbf{d}$. On this toy problem 225 runs is plenty. On a real model with $10^4$-$10^6$ parameters and a few hundred affordable runs, it is not obviously plenty, and there is no warning when it stops being enough.\n",
     "\n",
-    "**7. There is no free lunch on the model runs.** DSI moves the cost, it does not remove it. You still need a prior Monte Carlo ensemble big enough to span the behaviour you care about, and that ensemble is the expensive part. What DSI buys you is the ability to condition it - and re-condition it, with different data, different weights, different scenarios - for almost nothing."
+    "**7. It inherits every assumption in your prior.** DSI conditions the prior ensemble; it does not question it. If the prior parameterisation is too coarse - as we found out the hard way in the Monte Carlo and regularisation notebooks - DSI will hand you a posterior that is too narrow, with exactly the same confidence as a good one.\n",
+    "\n",
+    "**8. There is no free lunch on the model runs.** DSI moves the cost, it does not remove it. You still need a prior Monte Carlo ensemble big enough to span the behaviour you care about, and that ensemble is the expensive part. What DSI buys you is the ability to condition it - and re-condition it, with different data, different weights, different scenarios - for almost nothing."
    ]
   },
   {

--- a/tutorials/part1_14_dsi/freyberg_dsi.ipynb
+++ b/tutorials/part1_14_dsi/freyberg_dsi.ipynb
@@ -790,7 +790,7 @@
     "\n",
     "**`normal_score` - for anything at all.** Rank every value of an output within its own ensemble, then map that rank to the matching quantile of a standard normal. By construction the transformed marginal is *exactly* $N(0,1)$ - whatever shape it started with: skewed, bounded, bimodal, doesn't matter. No distributional assumption is being smuggled in. The inverse maps back through the empirical distribution, so returned values stay inside the range the training ensemble spanned, which gives physical feasibility for free. That same property is a limitation: it deliberately refuses to extrapolate, unless you ask it to with `quadratic_extrapolation=True`.\n",
     "\n",
-    "It also fixes the variance-scale problem we found earlier. Once every output has been mapped to $N(0,1)$ they all have unit variance, so no group can dominate the SVD by virtue of its units. Heads get a say again.\n",
+    "It also fixes the variance-scale problem we found earlier. Once every output has been mapped to $N(0,1)$ they all have unit variance, so no group can dominate the SVD by virtue of its units. Heads get a say again - and we will come back and look at what that does to the singular value spectrum, because the result is not what you would guess.\n",
     "\n",
     "### So pick the transform for the physics, not for convenience\n",
     "\n",
@@ -921,6 +921,67 @@
     "Both fit the data comfortably. The difference is that one of them produced answers that could actually happen.\n",
     "\n",
     "Here are the forecasts from the transformed emulator - the ones we should have been looking at all along:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### What the transform did to the emulator itself\n",
+    "\n",
+    "Worth going back to the singular value spectrum we looked at when we first fitted the emulator, and putting the transformed version next to it. The singular values are scaled to the first one in each case, since the transformed data has been standardised and the raw absolute magnitudes are no longer comparable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ce_untransformed = np.cumsum(dsi.s**2) / np.sum(dsi.s**2)\n",
+    "ce_transformed   = np.cumsum(dsi_tx.s**2) / np.sum(dsi_tx.s**2)\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(10.5, 3.8))\n",
+    "\n",
+    "axes[0].plot(dsi.s / dsi.s[0], color='0.5', label='untransformed')\n",
+    "axes[0].plot(dsi_tx.s / dsi_tx.s[0], 'b-', label='transformed')\n",
+    "axes[0].set_yscale('log')\n",
+    "axes[0].set_xlim(0, 60)\n",
+    "axes[0].set_xlabel('component')\n",
+    "axes[0].set_ylabel('singular value\\n(scaled to the first)')\n",
+    "axes[0].set_title('Singular value spectrum')\n",
+    "axes[0].legend(fontsize=8)\n",
+    "\n",
+    "axes[1].plot(np.arange(1,len(ce_untransformed)+1), ce_untransformed, color='0.5',\n",
+    "             label='untransformed')\n",
+    "axes[1].plot(np.arange(1,len(ce_transformed)+1), ce_transformed, 'b-',\n",
+    "             label='transformed')\n",
+    "axes[1].axhline(0.99, color='r', ls='--', lw=1.0, label='99% of variance')\n",
+    "axes[1].set_xlim(0, 60)\n",
+    "axes[1].set_xlabel('number of components')\n",
+    "axes[1].set_ylabel('cumulative share of variance')\n",
+    "axes[1].set_title('Cumulative energy')\n",
+    "axes[1].legend(fontsize=8)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "\n",
+    "for lbl, c in [('untransformed', ce_untransformed), ('transformed', ce_transformed)]:\n",
+    "    print(f'{lbl:14s}: {int(np.argmax(c>=0.99)+1):3d} components for 99% of the variance')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is the most surprising figure in the notebook. Transforming made the problem look **harder**: 99% of the variance now takes about 30 components where before it took 6.\n",
+    "\n",
+    "That is the right way round, and it is worth understanding why. The raw ensemble was not really low-dimensional - it only looked that way. Almost all of its absolute variance sat in a handful of large-magnitude outputs, so six components could account for 99% of it while barely describing the 325 head columns at all. The spectrum fell off a cliff not because there was no structure left, but because what remained was numerically tiny.\n",
+    "\n",
+    "After the normal-score transform every output has unit variance, so \"99% of the variance\" now means 99% of the variability across *all* the outputs, heads included. It takes 30 components to get there. That number is the honest one - this is what we meant earlier by heads getting a say again.\n",
+    "\n",
+    "Notice also that the leading component is *stronger* after transforming (about half the variance, against 38% before). That is a genuine common mode running through the standardised outputs, and it was previously masked by the scale differences. So the transformed spectrum is not simply flatter - it has a clearer dominant signal *and* a much longer tail.\n",
+    "\n",
+    "There is a cost, and it lands squarely on the next section. We have 225 realisations, so 225 directions available. Needing 30 components instead of 6 means spending rather more of that budget - and how much budget we have is set by how many times we could afford to run the model."
    ]
   },
   {

--- a/tutorials/part1_14_dsi/freyberg_dsi.ipynb
+++ b/tutorials/part1_14_dsi/freyberg_dsi.ipynb
@@ -1,0 +1,676 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Emulation - Data Space Inversion (DSI)\n",
+    "\n",
+    "Everything we have done so far has needed the model. GLM needed it to fill a Jacobian. Monte Carlo needed it once per realisation. iES needed it once per realisation *per iteration*. For the Freyberg model that is fine - it runs in a second. For a real model that takes an hour, it is the whole ballgame.\n",
+    "\n",
+    "*Data space inversion* (DSI) takes a different route. Instead of history matching the model, we history match a cheap statistical stand-in - an **emulator** - built from model runs we have already done. The emulator maps the statistical relationships between model outputs: between the outputs we have measurements for, and the outputs we care about forecasting. Conditioning happens in that output (\"data\") space, not in parameter space.\n",
+    "\n",
+    "The consequence is the interesting bit: **DSI needs no new model runs at all.** We already have a prior Monte Carlo ensemble from the iES notebook. That ensemble is all DSI needs.\n",
+    "\n",
+    "The trade is just as blunt: we give up parameters. A DSI posterior tells you about forecasts. It cannot tell you what hydraulic conductivity field produced them, because it never had one.\n",
+    "\n",
+    "See the original paper [Sun and Durlofsky (2017)](https://doi.org/10.1007/s11004-016-9672-8) and later variants (e.g. [Lima et al 2020](https://doi.org/10.1007/s10596-020-09933-w)). There are also [GMDSI webinars on YouTube](https://www.youtube.com/watch?v=s2g3HaJa1Wk&t=1564s). The [part2 DSI notebook](../part2_10_eva_and_dsi/2_freyberg_ensemble_data_space_inversion.ipynb) goes deeper, on a much higher-dimensional problem."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The Current Tutorial\n",
+    "\n",
+    "In this notebook we will:\n",
+    "1. Reuse the prior Monte Carlo ensemble from the iES notebook as training data - and screen it, because it needs it\n",
+    "2. Build a DSI emulator with `pyemu.emulators.DSI`\n",
+    "3. Condition it with `pestpp-ies`, using the same observations, weights and phi as every other part1 notebook\n",
+    "4. Compare the DSI forecast posterior against the iES forecast posterior\n",
+    "5. Be honest about what DSI cannot do\n",
+    "\n",
+    "### Admin\n",
+    "\n",
+    "> **This notebook needs the iES notebook to have been run first.** We use its prior observation ensemble as our training data, so run [part1_13](../part1_13_basic_ies/freyberg_ies.ipynb) before this one. We do *not* build or run the model here - that is rather the point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import os\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "warnings.filterwarnings(\"ignore\", category=DeprecationWarning)\n",
+    "\n",
+    "import time\n",
+    "import shutil\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt;\n",
+    "\n",
+    "import pyemu\n",
+    "import flopy\n",
+    "assert \"dependencies\" in flopy.__file__\n",
+    "assert \"dependencies\" in pyemu.__file__\n",
+    "sys.path.insert(0,\"..\")\n",
+    "import herebedragons as hbd\n",
+    "\n",
+    "plt.rcParams['font.size'] = 10\n",
+    "pyemu.plot_utils.font = 10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The training data\n",
+    "\n",
+    "DSI needs an ensemble of model outputs that spans **both** the quantities we have measurements for **and** the forecasts we care about. That is exactly what a prior Monte Carlo run produces, and it is the only time the model has to run.\n",
+    "\n",
+    "We already paid for one in the iES notebook: the prior ensemble, iteration 0 of the first `pestpp-ies` run. Let's go and get it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# the iES notebook's master directory - we are borrowing its results, not re-running anything\n",
+    "ies_d = os.path.join('..','part1_13_basic_ies','master_ies')\n",
+    "assert os.path.exists(ies_d), \"run the part1_13 iES notebook first!\"\n",
+    "\n",
+    "pst = pyemu.Pst(os.path.join(ies_d,'freyberg_pp.pst'))\n",
+    "\n",
+    "# iteration 0 is the prior - the model outputs before any data was assimilated\n",
+    "oe = pd.read_csv(os.path.join(ies_d,'freyberg_pp.0.obs.csv'),index_col=0)\n",
+    "oe.columns = [c.lower() for c in oe.columns]\n",
+    "oe = oe.astype(float)\n",
+    "oe.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So we have an ensemble of model outputs: one row per realisation, one column per observation in the control file. Note what is in there and what it cost us:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'realisations in the training data : {oe.shape[0]}')\n",
+    "print(f'model outputs per realisation     : {oe.shape[1]}')\n",
+    "print(f'non-zero weighted observations    : {pst.nnz_obs}')\n",
+    "print(f'observation groups being fitted    : {sorted(pst.nnz_obs_groups)}')\n",
+    "print(f'forecasts                         : {pst.forecast_names}')\n",
+    "print()\n",
+    "print('new model runs needed for DSI      : 0')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## First, screen the training data\n",
+    "\n",
+    "It is tempting to go straight to the emulator. Don't.\n",
+    "\n",
+    "DSI works by taking the principal components of the training data. Principal components are driven by **variance**, and variance is not robust: one output with a silly value in one realisation can swamp everything else. And a prior Monte Carlo run on a groundwater model *will* contain silly values - realisations where a cell went dry, or where the solver did not really converge.\n",
+    "\n",
+    "Heads in this model are a few tens of metres. Let's see if that is what we actually have."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head_obs = [o for o in oe.columns if o.startswith('trgw')]\n",
+    "\n",
+    "print('range of simulated heads across the whole prior ensemble:')\n",
+    "print(f'  min: {oe[head_obs].values.min():.3g}')\n",
+    "print(f'  max: {oe[head_obs].values.max():.3g}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ouch. A head of -1e15 m is not a water level, it is a model that fell over. Let's find out how widespread it is, and which outputs are affected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# a negative head is unambiguous garbage - there is no reading of this model in\n",
+    "# which a water level is -1e15 m\n",
+    "negative = (oe[head_obs] < 0).any(axis=1)\n",
+    "print(f'realisations with a negative head: {negative.sum()}')\n",
+    "\n",
+    "# the high end is less clear cut. Heads at the observation wells sit around\n",
+    "# 30-40 m, but the ensemble tails off smoothly - there is no obvious break\n",
+    "print('\\nper-realisation maximum head, quantiles:')\n",
+    "print(oe[head_obs].max(axis=1).quantile([0.5,0.9,0.95,0.99,1.0]).round(1).to_string())\n",
+    "\n",
+    "# which sites go bad, and how badly\n",
+    "worst = oe[head_obs].min().sort_values()\n",
+    "print('\\nworst five outputs (minimum value over the ensemble):')\n",
+    "print(worst.head(5).to_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now the part that matters. Is any of this contaminating something we care about?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# are the observations we are fitting affected? and the forecasts?\n",
+    "affected = worst[worst < 0].index.tolist()\n",
+    "print('contaminated outputs that are weighted observations:')\n",
+    "print(' ', [o for o in affected if o in pst.nnz_obs_names] or 'none')\n",
+    "print('contaminated outputs that are forecasts:')\n",
+    "print(' ', [o for o in affected if o in pst.forecast_names] or 'none')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is in both. Twelve of the observations we are *fitting* are contaminated - all at the `trgw-0-26-6` site - and so is `trgw-0-9-1:4383.5` - the groundwater level forecast we have been tracking since the trial-and-error notebook. These are not realisations that are slightly off; they are numerical garbage.\n",
+    "\n",
+    "Worth pausing on, because none of it is a DSI problem. It was sitting in the prior ensemble the whole time, quietly skewing the prior histograms back in the Monte Carlo and iES notebooks. DSI just makes it impossible to ignore, because of what variance does to principal components. Here is the damage, measured as the share of total ensemble variance sitting in a single output:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def cumulative_energy(data):\n",
+    "    \"\"\"the share of ensemble variance captured by each successive principal\n",
+    "    component - the same calculation DSI uses internally when deciding how\n",
+    "    many components to keep\"\"\"\n",
+    "    X = data.astype(float)\n",
+    "    z = (X - X.mean()) / np.sqrt(X.shape[0] - 1)\n",
+    "    s = np.linalg.svd(z.values, full_matrices=False)[1]\n",
+    "    return np.cumsum(s**2) / np.sum(s**2)\n",
+    "\n",
+    "\n",
+    "def n_components_for(ce, threshold):\n",
+    "    \"\"\"how many components are needed to reach `threshold` of the variance\"\"\"\n",
+    "    return int(np.argmax(ce >= threshold) + 1)\n",
+    "\n",
+    "\n",
+    "ce_raw = cumulative_energy(oe)\n",
+    "print(f'biggest single output as a share of total variance: '\n",
+    "      f'{100*oe.var().max()/oe.var().sum():.1f}%')\n",
+    "print()\n",
+    "print('components needed, using the raw ensemble:')\n",
+    "for t in [0.9, 0.99, 0.999]:\n",
+    "    print(f'  {t*100:5.1f}% of variance -> {n_components_for(ce_raw, t)} component(s)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "One component holds 99.9% of the \"variance\". That is not a low-dimensional problem, it is a broken one - the PCA is describing a single blown-up number and nothing else. An emulator fitted to this would be worthless.\n",
+    "\n",
+    "So we screen. We drop the offending realisations and keep the rest."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# drop the unambiguous failures, plus realisations whose heads climb implausibly\n",
+    "# high. The 100 m cut is OUR CHOICE - there is no break in the data to guide us,\n",
+    "# so this is a judgement about what is physically plausible. Change it and see\n",
+    "MAX_PLAUSIBLE_HEAD = 100.0\n",
+    "blown_up = negative | (oe[head_obs] > MAX_PLAUSIBLE_HEAD).any(axis=1)\n",
+    "\n",
+    "data = oe.loc[~blown_up, :]\n",
+    "print(f'training data: {data.shape[0]} realisations (dropped {blown_up.sum()})')\n",
+    "print(f'head range now: {data[head_obs].values.min():.2f} to {data[head_obs].values.max():.2f} m')\n",
+    "\n",
+    "ce = cumulative_energy(data)\n",
+    "print('\\ncomponents needed, after screening:')\n",
+    "for t in [0.9, 0.99, 0.999]:\n",
+    "    print(f'  {t*100:5.1f}% of variance -> {n_components_for(ce, t)} component(s)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Much healthier. The variance is now spread over many components, which is what we would expect from an ensemble that genuinely varies in a lot of directions.\n",
+    "\n",
+    "> **Lesson, and it is the most practical one in this notebook:** an emulator is only ever as good as the ensemble it was trained on. Screening the training data is not optional housekeeping, it is part of the method.\n",
+    "\n",
+    "Notice how little of that screening was objective. The negative heads decided themselves. The 100 m cut did not - the ensemble tails off smoothly, so we drew a line based on what we think a water level in this aquifer can plausibly be. Draw it at 60 m and you drop 44 realisations instead of 20; draw it at 200 m and you keep realisations that are probably junk. Like the streamflow weight back in part1_01, it is a subjective call that changes the answer, so make it deliberately and write it down.\n",
+    "\n",
+    "We also threw away whole realisations rather than individual outputs. That is another choice - we could have dropped the `trgw-0-24-4` site entirely and kept its realisations. Which is better depends on whether you need that site."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Building the emulator\n",
+    "\n",
+    "`pyemu.emulators` is the entry point for all things emulation. To build a `DSI` object we need the training data. Optionally we pass a `Pst`, which `DSI` uses later to help build a PEST interface for the emulator, plus transformations and an SVD truncation level.\n",
+    "\n",
+    "We will keep `energy_threshold=1.0`, which means no truncation - keep every component. For a problem this size that costs nothing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyemu.emulators import DSI\n",
+    "\n",
+    "dsi = DSI(pst=pst,               # optional; used to build the PEST interface later\n",
+    "          data=data,             # the training data - this is the required bit\n",
+    "          transforms=None,       # optional; see the limitations discussion below\n",
+    "          energy_threshold=1.0)  # 1.0 = keep every component\n",
+    "\n",
+    "dsi.fit();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`fit()` did the work: centre the training data, take its SVD, and store the projection that turns a vector of latent coefficients back into a full set of model outputs.\n",
+    "\n",
+    "The singular values tell us how much each component carries:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig,axes = plt.subplots(1,2,figsize=(9,3.5))\n",
+    "axes[0].plot(dsi.s,'b-')\n",
+    "axes[0].set_yscale('log')\n",
+    "axes[0].set_xlabel('component')\n",
+    "axes[0].set_ylabel('singular value')\n",
+    "axes[0].set_title('singular value spectrum')\n",
+    "\n",
+    "axes[1].plot(ce,'b-')\n",
+    "axes[1].axhline(0.99,color='r',ls='--',lw=1.0,label='99% of variance')\n",
+    "axes[1].set_xlabel('number of components')\n",
+    "axes[1].set_ylabel('cumulative share of variance')\n",
+    "axes[1].set_title('cumulative energy')\n",
+    "axes[1].legend()\n",
+    "plt.tight_layout();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What are the parameters now?\n",
+    "\n",
+    "This is the conceptual jump. Our model had 68 adjustable parameters: pilot point hydraulic conductivities and recharge. The emulator has none of them. Its \"parameters\" are the **latent coefficients** - the weights on each principal component of the output ensemble.\n",
+    "\n",
+    "To run the emulator, hand it a vector of those coefficients. That is the entire forward run:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'the emulator takes a vector of {dsi.s.shape[0]} latent coefficients')\n",
+    "\n",
+    "pvals = np.random.normal(0, 1, dsi.s.shape)\n",
+    "sim = dsi.predict(pvals)\n",
+    "\n",
+    "print(f'and returns {sim.shape[0]} simulated model outputs')\n",
+    "sim.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "No MODFLOW. No files. A matrix multiply.\n",
+    "\n",
+    "Notice what this buys and what it costs. Any vector of coefficients gives you a complete, self-consistent set of model outputs - heads, flows, travel time, historic and forecast - in microseconds. But there is no hydraulic conductivity field anywhere in that answer, and no way to get one back out."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A PEST interface for the emulator\n",
+    "\n",
+    "We now want `pestpp-ies` to adjust those latent coefficients until the emulated outputs match our measurements. That needs a control file, template files and instruction files - and `prepare_pestpp()` builds all of it.\n",
+    "\n",
+    "We pass `use_runstor=True`, which sets the emulator up to be driven through PEST++'s **external run manager**. More on why in a moment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t_d = 'dsi_template'\n",
+    "pst_dsi = dsi.prepare_pestpp(t_d=t_d, use_runstor=True)\n",
+    "\n",
+    "# prepare_pestpp builds a fresh control file, so the pestpp options from the model\n",
+    "# don't come across. We very much want our forecasts to travel with us\n",
+    "pst_dsi.pestpp_options['forecasts'] = pst.pestpp_options['forecasts']\n",
+    "assert pst_dsi.forecast_names == pst.forecast_names\n",
+    "\n",
+    "# and it doesn't copy binaries over either - note we need pestpp-ies, but no MODFLOW\n",
+    "hbd.prep_bins(t_d)\n",
+    "\n",
+    "sorted(os.listdir(t_d))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`dsi.pickle` is the fitted emulator. `dsi_pars.csv` holds the latent coefficients, `dsi_sim_vals.csv` the emulated outputs, and `forward_run.py` is the \"model\" - it loads the emulator and calls `predict()`.\n",
+    "\n",
+    "Let's see how the interface changed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'{\"\":22s}{\"model\":>10s}{\"emulator\":>10s}')\n",
+    "print(f'{\"adjustable parameters\":22s}{pst.npar_adj:>10d}{pst_dsi.npar_adj:>10d}')\n",
+    "print(f'{\"observations\":22s}{pst.nobs:>10d}{pst_dsi.nobs:>10d}')\n",
+    "print(f'{\"weighted observations\":22s}{pst.nnz_obs:>10d}{pst_dsi.nnz_obs:>10d}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The observations are identical - same 36 weighted observations, same groups, same weights. That is deliberate, and it is what makes this notebook comparable to the ones before it: **phi means the same thing here as it did in the GLM and iES notebooks.** Whatever number we end up with can be read against those.\n",
+    "\n",
+    "The parameters are a different animal entirely: latent coefficients instead of pilot points."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Guard against extrapolation\n",
+    "\n",
+    "An emulator interpolates between the runs it was trained on. Ask it to extrapolate and it will answer confidently and wrongly.\n",
+    "\n",
+    "The specific way this bites in DSI is *prior data conflict*: an observation whose measured value lies outside the range the training ensemble ever produced. There is no combination of latent coefficients that will reach it, so `pestpp-ies` will contort the whole ensemble trying. Better to detect those observations and drop them, which is what `ies_drop_conflicts` does. Turn it on - for DSI it should be the default."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pst_dsi.pestpp_options[\"ies_drop_conflicts\"] = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conditioning the emulator\n",
+    "\n",
+    "Now we run `pestpp-ies` on the emulator instead of on the model.\n",
+    "\n",
+    "One new thing here. Normally we deploy a swarm of PANTHER workers, each running the model in its own directory. That is the right design when the model takes minutes, but it is entirely wrong for DSI: the emulator run takes microseconds, so all the time goes into starting python and reading files. Deploying workers would make DSI a hundred times slower than it needs to be.\n",
+    "\n",
+    "Instead we use PEST++'s **external run manager**, with the `/e` switch. It works batch-wise: PEST++ writes every parameter set it wants evaluated into a run storage file (`dsi.rns`), calls the forward run **once**, and reads all the results back. So `dsi.predict()` gets called a single time per iteration, on the whole ensemble at once, in one process. No workers, no ports, no worker directories."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# as always, as many realisations as you can afford. Here that is all of them\n",
+    "pst_dsi.pestpp_options[\"ies_num_reals\"] = data.shape[0]\n",
+    "pst_dsi.control_data.noptmax = 3\n",
+    "pst_dsi.write(os.path.join(t_d,\"dsi.pst\"),version=2)\n",
+    "\n",
+    "# run in a copy, so the template folder stays clean\n",
+    "m_d = 'master_dsi'\n",
+    "if os.path.exists(m_d):\n",
+    "    shutil.rmtree(m_d)\n",
+    "shutil.copytree(t_d, m_d)\n",
+    "\n",
+    "start = time.time()\n",
+    "pyemu.os_utils.run(\"pestpp-ies dsi.pst /e\", cwd=m_d)\n",
+    "print(f'\\nconditioning took {time.time()-start:.1f} seconds')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Seconds. For comparison, the iES run in the previous notebook needed 50 model runs per iteration, and the prior Monte Carlo before it needed 250.\n",
+    "\n",
+    "Let's look at the objective function. Remember this is the *same* phi - same observations, same weights - that we have been minimising since the trial-and-error notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pst_dsi = pyemu.Pst(os.path.join(m_d,\"dsi.pst\"))\n",
+    "phidf = pd.read_csv(os.path.join(m_d,\"dsi.phi.actual.csv\"))\n",
+    "\n",
+    "fig,ax = plt.subplots(1,1,figsize=(5,4))\n",
+    "ax.plot(phidf.iteration, phidf['mean'], \"bo-\", label='ensemble mean phi')\n",
+    "ax.fill_between(phidf.iteration, phidf['min'], phidf['max'],\n",
+    "                color='b', alpha=0.15, label='ensemble min/max')\n",
+    "ax.axhline(pst_dsi.nnz_obs, color='r', ls='--', lw=1.5,\n",
+    "           label=f'nnz_obs = {pst_dsi.nnz_obs}')\n",
+    "ax.set_yscale('log')\n",
+    "ax.set_xlabel('iteration')\n",
+    "ax.set_ylabel('$\\\\Phi$')\n",
+    "ax.legend()\n",
+    "plt.tight_layout();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Phi drops hard, and then keeps going - straight past the number of non-zero weighted observations (the red line).\n",
+    "\n",
+    "That red line is a rough overfitting alarm. If weights were set as the inverse of the standard deviation of measurement noise, then a model fitting the data *as well as the noise allows* should land at a phi of roughly `nnz_obs`. Going well below it means we are fitting noise.\n",
+    "\n",
+    "But look closely at what our weights actually are. Throughout part1 we have used `HEAD_WEIGHT = 1.0` and `SFR_WEIGHT = 0.003` - numbers we chose for balance and visibility back in the trial-and-error notebook, not measurements of anything. They are not inverse noise standard deviations. `pestpp-ies` even told us as much in the record file: with no noise information available it fell back to `ies_no_noise`, so there is no noise floor for phi to respect.\n",
+    "\n",
+    "So we cannot actually tell, from this run, whether we are overfitting. That is not a DSI flaw - it is the bill arriving for a subjective weighting choice made twelve notebooks ago. Part2 does this properly, assigning weights as `1/standard_deviation` so that the `nnz_obs` line means something."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Did it fit?\n",
+    "\n",
+    "Same stochastic 1-to-1 plot we have used since the iES notebook, so you can flip between the two. Prior in grey, posterior in blue."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oe_pr_dsi, oe_pt_dsi = hbd.load_ies_obs_ensembles(m_d, case='dsi')\n",
+    "hbd.plot_1to1_ensemble(pst_dsi, prior=oe_pr_dsi, posterior=oe_pt_dsi,\n",
+    "                       title='DSI emulator');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The emulator fits the measured data well - unsurprising, given the phi history. The question that actually matters is whether it gets the *forecasts* right."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Predictive uncertainty analysis\n",
+    "\n",
+    "This is what we came for. Prior in grey, posterior in blue, and the truth as a dashed black line. Remember we only know the truth because this is a synthetic problem - and remember that a forecast is a success only if the posterior *brackets* the truth, not if it hits it exactly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for forecast in pst_dsi.forecast_names:\n",
+    "    fig,ax = plt.subplots(1,1,figsize=(5,2.8))\n",
+    "    oe_pr_dsi.loc[:,forecast].hist(bins=20,alpha=0.5,color=\"0.5\",ax=ax,label='prior')\n",
+    "    oe_pt_dsi.loc[:,forecast].hist(bins=20,alpha=0.5,color=\"b\",ax=ax,label='posterior')\n",
+    "    v = pst_dsi.observation_data.loc[forecast,\"obsval\"]\n",
+    "    ax.axvline(v,color='k',ls='--',lw=2.0,label='truth')\n",
+    "    ax.set_ylabel('count')\n",
+    "    ax.set_title(forecast)\n",
+    "    ax.legend(fontsize=8)\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How does that compare to iES?\n",
+    "\n",
+    "DSI and iES are answering the same question from the same prior ensemble. iES did it by adjusting model parameters and re-running the model. DSI did it by adjusting latent coefficients and never touching the model. If they agree, that is a strong argument for using the cheap one.\n",
+    "\n",
+    "Let's put them side by side. The iES posterior is the last iteration of the second run in the previous notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# the iES posterior from the previous notebook\n",
+    "ies_d1 = os.path.join('..','part1_13_basic_ies','master_ies1')\n",
+    "oe_pt_ies = pd.read_csv(os.path.join(ies_d1,'freyberg_pp.5.obs.csv'),index_col=0)\n",
+    "oe_pt_ies.columns = [c.lower() for c in oe_pt_ies.columns]\n",
+    "\n",
+    "fig,axes = plt.subplots(1,len(pst_dsi.forecast_names),\n",
+    "                        figsize=(4*len(pst_dsi.forecast_names),3.2))\n",
+    "for ax,forecast in zip(axes,pst_dsi.forecast_names):\n",
+    "    ax.hist(oe_pt_ies.loc[:,forecast].values,bins=15,alpha=0.5,\n",
+    "            color='g',density=True,label='iES posterior')\n",
+    "    ax.hist(oe_pt_dsi.loc[:,forecast].values,bins=15,alpha=0.5,\n",
+    "            color='b',density=True,label='DSI posterior')\n",
+    "    v = pst_dsi.observation_data.loc[forecast,\"obsval\"]\n",
+    "    ax.axvline(v,color='k',ls='--',lw=2.0,label='truth')\n",
+    "    ax.set_title(forecast)\n",
+    "    ax.set_yticks([])\n",
+    "    ax.legend(fontsize=8)\n",
+    "plt.tight_layout();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Have a good look at these. Where the two agree, DSI has given us the same answer for a tiny fraction of the compute. Where they disagree, the interesting question is *which one to believe* - and note that neither is automatically right. The two runs also used different ensemble sizes, so some of the difference is just sampling."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Limitations\n",
+    "\n",
+    "DSI is fast, it is easy to run, and it is genuinely useful. It is not magic, and the ways it fails are not always loud. In rough order of how often they bite:\n",
+    "\n",
+    "**1. It cannot go outside its training data.** The emulator is a weighted recombination of the ensemble it was fitted to. If no realisation ever produced a low enough streamflow, no combination of latent coefficients will produce one either. When the measured data sits outside that envelope you get prior data conflict - which is why `ies_drop_conflicts` should always be on, and why a conflict is a message about your prior, not a nuisance to be silenced. If you need to go somewhere the ensemble never went, the fix is more model runs, not a cleverer emulator.\n",
+    "\n",
+    "**2. Garbage in, garbage out - and it is worse than usual.** We spent the first third of this notebook on this for good reason. Because DSI is built on variance, one blown-up realisation does not just add noise, it can consume the entire latent space. Always look at your training data before you fit.\n",
+    "\n",
+    "**3. The PCA is done on raw, unstandardised outputs.** Components are ranked by absolute variance, so outputs with big numbers dominate outputs with small ones. Streamflows here are ~2500 m³/d and heads are ~35 m, so streamflow contributes far more \"variance\" while carrying no more information. This is also why `energy_threshold` truncation is close to useless on this problem. The remedies are transformations - `log10` for quantities spanning orders of magnitude, normal-score transforms for skewed ones - and row-wise scaling by observation group. All are available through the `transforms` and `rowwise_groups` arguments; part2 shows them in use.\n",
+    "\n",
+    "**4. No parameters means no parameter insight.** You cannot ask a DSI posterior which part of the aquifer is transmissive, look at a posterior hydraulic conductivity field, or check whether a realisation is physically sensible. If your question is \"what is the forecast and how uncertain is it\", that is fine. If your question is \"why\", DSI cannot answer it.\n",
+    "\n",
+    "**5. Conditioning is linear-Gaussian in the latent space.** DSI assumes the relationship between observations and forecasts is captured by the covariance of the training ensemble. Strong nonlinearity gets smeared out. One visible symptom is emulated time series that go saw-toothed in the forecast period - smooth where there is data to pin them down, jumping around where there is not. Part2 shows this clearly.\n",
+    "\n",
+    "**6. It inherits every assumption in your prior.** DSI conditions the prior ensemble; it does not question it. If the prior parameterisation is too coarse - as we found out the hard way in the Monte Carlo and regularisation notebooks - DSI will hand you a posterior that is too narrow, with exactly the same confidence as a good one. It is not a way to escape a badly posed problem.\n",
+    "\n",
+    "**7. There is no free lunch on the model runs.** DSI moves the cost, it does not remove it. You still need a prior Monte Carlo ensemble big enough to span the behaviour you care about, and that ensemble is the expensive part. What DSI buys you is the ability to condition it - and re-condition it, with different data, different weights, different scenarios - for almost nothing."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## So where does that leave us?\n",
+    "\n",
+    "DSI is the first method in these tutorials that decouples the cost of history matching from the cost of running the model. For the Freyberg model that is a curiosity. For a model that takes an hour a run, it is the difference between an uncertainty analysis and no uncertainty analysis.\n",
+    "\n",
+    "The catch is that it buys speed with assumptions, and it is quiet about them. Everything in the limitations list above will hold whether or not you check for it.\n",
+    "\n",
+    "Next steps:\n",
+    "- [part2_10](../part2_10_eva_and_dsi/2_freyberg_ensemble_data_space_inversion.ipynb) does DSI on the high-dimensional part2 problem, with transformations, noise-based weights and time-series diagnostics\n",
+    "- the same folder has notebooks on ensemble data worth and on PLS emulation, for comparison"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tutorials/part1_14_dsi/freyberg_dsi.ipynb
+++ b/tutorials/part1_14_dsi/freyberg_dsi.ipynb
@@ -1033,10 +1033,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# the iES posterior from the previous notebook\n",
+    "# the iES posterior from the previous notebook - load_ies_obs_ensembles reads\n",
+    "# whichever iteration PESTPP-IES actually finished on, rather than assuming\n",
     "ies_d1 = os.path.join('..','part1_13_basic_ies','master_ies1')\n",
-    "oe_pt_ies = pd.read_csv(os.path.join(ies_d1,'freyberg_pp.5.obs.csv'),index_col=0)\n",
-    "oe_pt_ies.columns = [c.lower() for c in oe_pt_ies.columns]\n",
+    "_, oe_pt_ies = hbd.load_ies_obs_ensembles(ies_d1, case='freyberg_pp')\n",
     "\n",
     "fig,axes = plt.subplots(1,len(pst_tx.forecast_names),\n",
     "                        figsize=(4*len(pst_tx.forecast_names),3.2))\n",

--- a/tutorials/part1_14_dsi/freyberg_dsi.ipynb
+++ b/tutorials/part1_14_dsi/freyberg_dsi.ipynb
@@ -21,6 +21,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## How DSI works, briefly\n",
+    "\n",
+    "Write $\\mathbf{d}$ for the vector of *all* model outputs - the ones we have measurements for and the forecasts, stacked together. A prior Monte Carlo run gives us $N_e$ realisations of it. Centre them and scale by $\\sqrt{N_e-1}$:\n",
+    "\n",
+    "$$\\Delta\\mathbf{D} = \\frac{1}{\\sqrt{N_e-1}}\\left[\\mathbf{d}_1-\\bar{\\mathbf{d}},\\;\\dots,\\;\\mathbf{d}_{N_e}-\\bar{\\mathbf{d}}\\right]$$\n",
+    "\n",
+    "so that $\\mathbf{C}_{dd} = \\Delta\\mathbf{D}\\,\\Delta\\mathbf{D}^T$ is the sample covariance of the outputs - the thing that encodes how every output co-varies with every other, including how the measured quantities co-vary with the forecasts. Take its SVD, $\\Delta\\mathbf{D} = \\mathbf{U}\\mathbf{S}\\mathbf{V}^T$.\n",
+    "\n",
+    "Now the trick. Instead of parameterising the *model*, DSI parameterises the *outputs*:\n",
+    "\n",
+    "$$\\mathbf{d}(\\boldsymbol{\\xi}) = \\bar{\\mathbf{d}} + \\mathbf{U}\\mathbf{S}\\,\\boldsymbol{\\xi}$$\n",
+    "\n",
+    "That is the entire emulator. Feed it a vector $\\boldsymbol{\\xi}$ of latent coefficients, get back a complete set of model outputs.\n",
+    "\n",
+    "Why is that a sensible thing to do? Because if we give $\\boldsymbol{\\xi}$ a standard normal prior, $\\boldsymbol{\\xi}\\sim N(\\mathbf{0},\\mathbf{I})$, then\n",
+    "\n",
+    "$$\\mathrm{Cov}\\left[\\mathbf{U}\\mathbf{S}\\boldsymbol{\\xi}\\right] = \\mathbf{U}\\mathbf{S}\\,\\mathbf{I}\\,\\mathbf{S}^T\\mathbf{U}^T = \\mathbf{U}\\mathbf{S}^2\\mathbf{U}^T = \\mathbf{C}_{dd}$$\n",
+    "\n",
+    "The emulator reproduces the prior covariance of the model outputs *exactly*. That is why the latent parameters get a mean of zero and a standard deviation of one - and it is literally what `prepare_pestpp` writes into `dsi.unc` for us later.\n",
+    "\n",
+    "History matching is then: find the $\\boldsymbol{\\xi}$ values whose measured-quantity entries match our observations. Because $\\boldsymbol{\\xi}\\mapsto\\mathbf{d}$ is **linear** and the prior on $\\boldsymbol{\\xi}$ is **Gaussian**, this is the linear-Gaussian Bayesian problem - the same one FOSM solves, but posed in output space instead of parameter space. `pestpp-ies` solves it iteratively, and because it is iterative it copes with the mild nonlinearity that transformations introduce (more on those later).\n",
+    "\n",
+    "Two things to notice, because both come back to bite us:\n",
+    "\n",
+    "1. The model appears nowhere in that equation. Once $\\mathbf{U}$ and $\\mathbf{S}$ are computed, MODFLOW is done.\n",
+    "2. Everything rests on $\\mathbf{C}_{dd}$ - a mean and a covariance. Those two moments pin down a distribution **only if that distribution is Gaussian**. Hold that thought."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## The Current Tutorial\n",
     "\n",
     "In this notebook we will:\n",
@@ -196,7 +228,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is in both. Twelve of the observations we are *fitting* are contaminated - all at the `trgw-0-26-6` site - and so is `trgw-0-9-1:4383.5` - the groundwater level forecast we have been tracking since the trial-and-error notebook. These are not realisations that are slightly off; they are numerical garbage.\n",
+    "It is in both. Twelve of the observations we are *fitting* are contaminated - all at the `trgw-0-26-6` site - and so is `trgw-0-9-1:4383.5`, the groundwater level forecast we have been tracking since the trial-and-error notebook. These are not realisations that are slightly off; they are numerical garbage.\n",
     "\n",
     "Worth pausing on, because none of it is a DSI problem. It was sitting in the prior ensemble the whole time, quietly skewing the prior histograms back in the Monte Carlo and iES notebooks. DSI just makes it impossible to ignore, because of what variance does to principal components. Here is the damage, measured as the share of total ensemble variance sitting in a single output:"
    ]
@@ -272,7 +304,39 @@
     "\n",
     "Notice how little of that screening was objective. The negative heads decided themselves. The 100 m cut did not - the ensemble tails off smoothly, so we drew a line based on what we think a water level in this aquifer can plausibly be. Draw it at 60 m and you drop 44 realisations instead of 20; draw it at 200 m and you keep realisations that are probably junk. Like the streamflow weight back in part1_01, it is a subjective call that changes the answer, so make it deliberately and write it down.\n",
     "\n",
-    "We also threw away whole realisations rather than individual outputs. That is another choice - we could have dropped the `trgw-0-24-4` site entirely and kept its realisations. Which is better depends on whether you need that site."
+    "We also threw away whole realisations rather than individual outputs. That is another choice - we could have dropped the `trgw-0-24-4` site entirely and kept its realisations. Which is better depends on whether you need that site.\n",
+    "\n",
+    "There is a second scale problem hiding underneath this one, though, and screening does not touch it. Look at where the variance actually lives now:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# how much of the ensemble variance does each observation group carry?\n",
+    "groups = pst.observation_data.groupby('obgnme').obsnme.apply(list)\n",
+    "rows = []\n",
+    "for grp, names in groups.items():\n",
+    "    names = [n for n in names if n in data.columns]\n",
+    "    if len(names) == 0:\n",
+    "        continue\n",
+    "    rows.append((grp, len(names), data[names].var().sum()))\n",
+    "vardf = pd.DataFrame(rows, columns=['group','nobs','total_variance'])\n",
+    "vardf['share_%'] = 100 * vardf.total_variance / vardf.total_variance.sum()\n",
+    "vardf.sort_values('share_%', ascending=False).round(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Streamflow and particle travel time carry essentially all of it. Every head site rounds to **0.0%** - and heads are half of the observations we are actually fitting.\n",
+    "\n",
+    "This is not because heads are uninformative. It is because an SVD ranks directions by *absolute* variance and has no idea that one column is in metres and another is in cubic metres per day. Head variance across this ensemble is around $10^3$; streamflow variance is around $10^8$. The components will describe streamflow and ignore heads, whatever we do with weights later.\n",
+    "\n",
+    "So the emulator we are about to build is, in effect, a model of the flows. We will come back and fix this once we have seen what else needs fixing."
    ]
   },
   {
@@ -587,6 +651,257 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Hold on - are these answers even possible?\n",
+    "\n",
+    "Before we celebrate, let's ask something the fit statistics cannot tell us: are the numbers the emulator produced physically possible at all?\n",
+    "\n",
+    "Streamflow in a river cannot be negative. Neither can a particle travel time. Let's count."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check_feasible(oe_post, label):\n",
+    "    \"\"\"count values the emulator produced that cannot physically happen\"\"\"\n",
+    "    gage = [n for n in groups['gage-1'] if n in oe_post.columns]\n",
+    "    neg = (oe_post[gage] < 0)\n",
+    "    ptime = oe_post['part_time']\n",
+    "    print(f'[{label}]')\n",
+    "    print(f'  negative streamflow  : {int(neg.values.sum())} values, in '\n",
+    "          f'{int(neg.any(axis=1).sum())} of {oe_post.shape[0]} realisations')\n",
+    "    print(f'  lowest streamflow    : {oe_post[gage].values.min():,.1f} m3/d')\n",
+    "    print(f'  negative travel times: {int((ptime<0).sum())}, '\n",
+    "          f'lowest {ptime.min():,.1f} days')\n",
+    "\n",
+    "\n",
+    "check_feasible(oe_pt_dsi, 'untransformed')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That is not a rounding problem. A large fraction of our posterior realisations contain rivers flowing backwards at thousands of cubic metres a day, and some contain particles that arrive before they set off.\n",
+    "\n",
+    "Every one of those realisations went into the forecast histograms above."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Why this happens: the normality assumption\n",
+    "\n",
+    "Go back to the emulator equation:\n",
+    "\n",
+    "$$\\mathbf{d}(\\boldsymbol{\\xi}) = \\bar{\\mathbf{d}} + \\mathbf{U}\\mathbf{S}\\,\\boldsymbol{\\xi}, \\qquad \\boldsymbol{\\xi}\\sim N(\\mathbf{0},\\mathbf{I})$$\n",
+    "\n",
+    "We showed that this reproduces $\\mathbf{C}_{dd}$ exactly. What we glossed over is that a mean and a covariance **do not describe a distribution** - unless that distribution happens to be Gaussian. The multivariate normal is the one family that is completely determined by its first two moments. For anything else, matching the mean and covariance matches two summary statistics and throws the rest away.\n",
+    "\n",
+    "So what does DSI actually generate? A linear combination of Gaussian variables is Gaussian. Which means $\\mathbf{d}(\\boldsymbol{\\xi})$ is **multivariate normal, by construction** - regardless of what our prior ensemble looked like. If the outputs really were Gaussian, that is exact and free. If they were not, DSI has quietly replaced their distribution with the Gaussian that shares its mean and covariance.\n",
+    "\n",
+    "That substitution has a specific and damaging consequence: **a Gaussian has infinite support in every direction.** It puts probability mass everywhere from $-\\infty$ to $+\\infty$. Nothing in the algebra knows that streamflow stops at zero, or that travel time does. So it strays past the bounds, and the negative flows above are exactly that happening.\n",
+    "\n",
+    "Are our outputs Gaussian? Not remotely - and we can measure it. Skewness is zero for any symmetric distribution:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scipy.stats import skew\n",
+    "\n",
+    "print('how skewed are the training-data marginals? (0 = symmetric)')\n",
+    "for grp in ['gage-1','particle','headwater','trgw-0-3-8']:\n",
+    "    names = [n for n in groups[grp] if n in data.columns]\n",
+    "    sk = np.abs(skew(data[names].values, axis=0))\n",
+    "    print(f'  {grp:12s} mean |skew| = {sk.mean():5.2f}   worst = {sk.max():5.2f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Strongly skewed, all of them - which is entirely normal for groundwater model outputs. Fluxes and travel times are bounded below and have long right tails; that is what they *are*.\n",
+    "\n",
+    "## Transformations: getting closer to normal\n",
+    "\n",
+    "We cannot make the outputs Gaussian. But we can history match a *transformed* version of them that is much closer to Gaussian, and then map back. If $g$ is monotonic and invertible, doing DSI on $g(\\mathbf{d})$ and reporting $g^{-1}$ of the result is a legitimate change of variables - the SVD, the standard-normal prior and the linear-Gaussian update all happen in transformed space, where the assumption is much less of a lie.\n",
+    "\n",
+    "Two transforms do most of the work, and they solve two different problems.\n",
+    "\n",
+    "**`log10` - for strictly positive, right-skewed quantities.** The log of a lognormal variable is *exactly* normal, and plenty of hydrologic quantities are roughly lognormal. It also fixes feasibility for free, and structurally rather than by luck: the inverse transform is $10^x$, which is positive for every real $x$. A log-transformed output *cannot* come back negative, no matter what the latent coefficients do.\n",
+    "\n",
+    "**`normal_score` - for anything at all.** Rank every value of an output within its own ensemble, then map that rank to the matching quantile of a standard normal. By construction the transformed marginal is *exactly* $N(0,1)$ - whatever shape it started with: skewed, bounded, bimodal, doesn't matter. The inverse maps back through the empirical distribution, so returned values stay inside (roughly) the range the training ensemble spanned. Feasibility again comes for free.\n",
+    "\n",
+    "It also fixes the variance-scale problem we found earlier. Once every output has been mapped to $N(0,1)$, they all have unit variance, so no group can dominate the SVD by virtue of its units. Heads get a say again.\n",
+    "\n",
+    "### But know what you are transforming\n",
+    "\n",
+    "This is where it is easy to do real damage. \"Log the fluxes\" is wrong advice here, and the model will not warn you:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for grp in ['gage-1','headwater','tailwater','particle']:\n",
+    "    names = [n for n in groups[grp] if n in data.columns]\n",
+    "    v = data[names].values\n",
+    "    print(f'{grp:11s} min = {v.min():12,.1f}   values <= 0: {int((v<=0).sum()):5d} of {v.size}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- `part_time` is strictly positive. `log10` is a good fit.\n",
+    "- `gage-1` is non-negative but hits **exactly zero** - the river dries up in some realisations. $\\log_{10}(0)$ is undefined, so a plain log breaks. You would need an offset, or a different transform.\n",
+    "- `headwater` and `tailwater` are **negative most of the time**, and rightly so: they are groundwater/surface-water *exchange* fluxes, where the sign tells you which way the water goes. Log-transforming them is not a numerical inconvenience, it is a category error.\n",
+    "\n",
+    "So: `log10` on the travel time, `normal_score` on everything else. The transforms are applied in the order listed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transforms = [\n",
+    "    # strictly positive and skewed - and log10 guarantees it comes back positive\n",
+    "    {'type':'log10', 'columns':['part_time']},\n",
+    "    # everything else, whatever its shape or sign. Also puts every output on the\n",
+    "    # same footing, so heads are no longer swamped by flows in the SVD\n",
+    "    {'type':'normal_score'},\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now rebuild and re-condition. These are the same steps we just worked through, wrapped in a function so we can run them again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_and_condition(transforms, tag, noptmax=3):\n",
+    "    \"\"\"fit a DSI emulator, build a PEST interface for it, and condition it -\n",
+    "    exactly the steps we did by hand above\"\"\"\n",
+    "    dsi = DSI(pst=pst, data=data, transforms=transforms, energy_threshold=1.0)\n",
+    "    dsi.fit()\n",
+    "\n",
+    "    t_d = f'template_{tag}'\n",
+    "    p = dsi.prepare_pestpp(t_d=t_d, use_runstor=True)\n",
+    "    p.pestpp_options['forecasts'] = pst.pestpp_options['forecasts']\n",
+    "    hbd.prep_bins(t_d)\n",
+    "    p.pestpp_options['ies_drop_conflicts'] = True\n",
+    "    p.pestpp_options['ies_num_reals'] = data.shape[0]\n",
+    "    p.control_data.noptmax = noptmax\n",
+    "    p.write(os.path.join(t_d,'dsi.pst'), version=2)\n",
+    "\n",
+    "    m_d = f'master_dsi_{tag}'\n",
+    "    if os.path.exists(m_d):\n",
+    "        shutil.rmtree(m_d)\n",
+    "    shutil.copytree(t_d, m_d)\n",
+    "    pyemu.os_utils.run(\"pestpp-ies dsi.pst /e\", cwd=m_d)\n",
+    "    return dsi, m_d\n",
+    "\n",
+    "\n",
+    "dsi_tx, m_d_tx = build_and_condition(transforms, 'tx')\n",
+    "pst_tx = pyemu.Pst(os.path.join(m_d_tx,'dsi.pst'))\n",
+    "oe_pr_tx, oe_pt_tx = hbd.load_ies_obs_ensembles(m_d_tx, case='dsi')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And the question that started this section:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check_feasible(oe_pt_dsi, 'untransformed')\n",
+    "print()\n",
+    "check_feasible(oe_pt_tx, 'transformed')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Gone. Not reduced - gone, and gone by construction rather than by good fortune. The lowest streamflow the transformed emulator can produce is the lowest one in the training ensemble, because that is what the inverse normal-score transform maps back to.\n",
+    "\n",
+    "Let's also check we did not wreck the fit to get here:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for tag, m_d in [('untransformed','master_dsi'), ('transformed', m_d_tx)]:\n",
+    "    phi = pd.read_csv(os.path.join(m_d,'dsi.phi.actual.csv'))\n",
+    "    print(f'{tag:14s} phi: {phi[\"mean\"].iloc[0]:8.1f} -> {phi[\"mean\"].iloc[-1]:6.2f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Both fit the data comfortably. The difference is that one of them produced answers that could actually happen.\n",
+    "\n",
+    "Here are the forecasts from the transformed emulator - the ones we should have been looking at all along:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for forecast in pst_tx.forecast_names:\n",
+    "    fig,ax = plt.subplots(1,1,figsize=(5,2.8))\n",
+    "    oe_pr_tx.loc[:,forecast].hist(bins=20,alpha=0.5,color=\"0.5\",ax=ax,label='prior')\n",
+    "    oe_pt_tx.loc[:,forecast].hist(bins=20,alpha=0.5,color=\"b\",ax=ax,label='posterior')\n",
+    "    v = pst_tx.observation_data.loc[forecast,\"obsval\"]\n",
+    "    ax.axvline(v,color='k',ls='--',lw=2.0,label='truth')\n",
+    "    ax.set_ylabel('count')\n",
+    "    ax.set_title(f'{forecast}  (transformed)')\n",
+    "    ax.legend(fontsize=8)\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **One honest caveat.** A normal-score transform makes each output's *marginal* distribution exactly normal. It does **not** make the *joint* distribution multivariate normal - that would need the dependence between outputs to be linear too, and it generally is not. So transforms get us much closer to the assumption DSI needs, and they buy us physical feasibility outright, but they do not make the assumption true. Nonlinear relationships between observations and forecasts still get smeared."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### How does that compare to iES?\n",
     "\n",
     "DSI and iES are answering the same question from the same prior ensemble. iES did it by adjusting model parameters and re-running the model. DSI did it by adjusting latent coefficients and never touching the model. If they agree, that is a strong argument for using the cheap one.\n",
@@ -605,12 +920,12 @@
     "oe_pt_ies = pd.read_csv(os.path.join(ies_d1,'freyberg_pp.5.obs.csv'),index_col=0)\n",
     "oe_pt_ies.columns = [c.lower() for c in oe_pt_ies.columns]\n",
     "\n",
-    "fig,axes = plt.subplots(1,len(pst_dsi.forecast_names),\n",
-    "                        figsize=(4*len(pst_dsi.forecast_names),3.2))\n",
-    "for ax,forecast in zip(axes,pst_dsi.forecast_names):\n",
+    "fig,axes = plt.subplots(1,len(pst_tx.forecast_names),\n",
+    "                        figsize=(4*len(pst_tx.forecast_names),3.2))\n",
+    "for ax,forecast in zip(axes,pst_tx.forecast_names):\n",
     "    ax.hist(oe_pt_ies.loc[:,forecast].values,bins=15,alpha=0.5,\n",
     "            color='g',density=True,label='iES posterior')\n",
-    "    ax.hist(oe_pt_dsi.loc[:,forecast].values,bins=15,alpha=0.5,\n",
+    "    ax.hist(oe_pt_tx.loc[:,forecast].values,bins=15,alpha=0.5,\n",
     "            color='b',density=True,label='DSI posterior')\n",
     "    v = pst_dsi.observation_data.loc[forecast,\"obsval\"]\n",
     "    ax.axvline(v,color='k',ls='--',lw=2.0,label='truth')\n",
@@ -639,11 +954,11 @@
     "\n",
     "**2. Garbage in, garbage out - and it is worse than usual.** We spent the first third of this notebook on this for good reason. Because DSI is built on variance, one blown-up realisation does not just add noise, it can consume the entire latent space. Always look at your training data before you fit.\n",
     "\n",
-    "**3. The PCA is done on raw, unstandardised outputs.** Components are ranked by absolute variance, so outputs with big numbers dominate outputs with small ones. Streamflows here are ~2500 m³/d and heads are ~35 m, so streamflow contributes far more \"variance\" while carrying no more information. This is also why `energy_threshold` truncation is close to useless on this problem. The remedies are transformations - `log10` for quantities spanning orders of magnitude, normal-score transforms for skewed ones - and row-wise scaling by observation group. All are available through the `transforms` and `rowwise_groups` arguments; part2 shows them in use.\n",
+    "**3. Untransformed, the whole thing rests on a normality assumption it does not meet.** This is the one we spent most of the notebook on. The reparameterisation reproduces a mean and a covariance, which describes a distribution only if it is Gaussian - and a Gaussian has infinite support, so the emulator cheerfully produced negative streamflow in 42% of realisations. On top of that, an SVD ranks directions by absolute variance and does not know metres from m³/d, so head observations contributed 0.0% of the components before we transformed. Transformations address both, and `normal_score` addresses them at the same time. They are not an optional refinement - treat an untransformed DSI run as a first sketch, not an answer. But pick them for what the quantity physically is: `log10` on a signed exchange flux is a category error, not a tuning choice. `rowwise_groups` is the other lever, scaling each observation group before the SVD.\n",
     "\n",
     "**4. No parameters means no parameter insight.** You cannot ask a DSI posterior which part of the aquifer is transmissive, look at a posterior hydraulic conductivity field, or check whether a realisation is physically sensible. If your question is \"what is the forecast and how uncertain is it\", that is fine. If your question is \"why\", DSI cannot answer it.\n",
     "\n",
-    "**5. Conditioning is linear-Gaussian in the latent space.** DSI assumes the relationship between observations and forecasts is captured by the covariance of the training ensemble. Strong nonlinearity gets smeared out. One visible symptom is emulated time series that go saw-toothed in the forecast period - smooth where there is data to pin them down, jumping around where there is not. Part2 shows this clearly.\n",
+    "**5. Conditioning is linear-Gaussian in the latent space, and transforms only get you closer.** DSI assumes the relationship between observations and forecasts is captured by the covariance of the training ensemble. A normal-score transform makes each output's marginal exactly normal, but it does not make the joint distribution multivariate normal, so nonlinear dependence between observations and forecasts still gets smeared. One visible symptom is emulated time series that go saw-toothed in the forecast period - smooth where there is data to pin them down, jumping around where there is not. Part2 shows this clearly.\n",
     "\n",
     "**6. It inherits every assumption in your prior.** DSI conditions the prior ensemble; it does not question it. If the prior parameterisation is too coarse - as we found out the hard way in the Monte Carlo and regularisation notebooks - DSI will hand you a posterior that is too narrow, with exactly the same confidence as a good one. It is not a way to escape a badly posed problem.\n",
     "\n",


### PR DESCRIPTION
Adds a part1 notebook on DSI (data space inversion), carrying on from the iES notebook.

The pitch: build an emulator out of the prior ensemble part1_13 already produced, condition it with pestpp-ies, and get forecast uncertainty out of it - with no new model runs at all. The whole conditioning run takes about 10 seconds.

What's in it:

- **Training data comes from part1_13.** We reuse its prior obs ensemble, so DSI costs nothing extra. That is the whole point of the method and the notebook leans on it.
- **Screening the training data first**, because it needs it. 12 of the 245 realisations have heads down to -1e15 (dry cells / solver trouble), which contaminates 12 of the weighted obs and the trgw-0-9-1 forecast. Left alone, one single output holds 100% of the ensemble variance and the PCA describes nothing but that. Note part1_12's `le(-2.e27)` filter does not catch this. The notebook is also up front that the "plausible head" cutoff is a subjective call, same as the sfr weight back in part1_01.
- **The maths**, using the same notation as the part0 intro-to-eva-and-dsi notebook (Cd, DeltaD, Sigma, x for the latent pars).
- **Transforms.** Untransformed, the emulator puts out negative streamflow in 94 of 225 posterior realisations, down to -16,433 m3/d, plus 37 negative travel times. With log10 on part_time and normal score on everything else: none of either. It also shows why you cannot just log the fluxes - headwater and tailwater are gw/sw exchange fluxes and are negative most of the time, and pyemu's log10 will happily shift and log them without complaining.
- **Curse of dimensionality.** Re-conditions the emulator on smaller random subsets of the same training data, 4 subsets per size. The posterior gets *narrower* as Ne shrinks, which is backwards, and below the full ensemble it stops containing the truth for part_time. Small ensemble = narrower and wrong, with no diagnostic to warn you.
- **Limitations section** at the end - extrapolation, model-of-the-model, dimensionality, and the rest.

Two implementation notes:

- Uses the external run manager (`pestpp-ies dsi.pst /e`) instead of panther workers. An emulator run is microseconds, so worker startup and file i/o would be the entire cost. With `/e` pestpp writes all the pending parameter sets into a run store, calls the forward run once, and reads the lot back.
- Registered `part1_14` in `PART1_ORDER`, since it reads part1_13's master dir and has to run after it.

Runtime is about 7 min locally on the full 225-realisation ensemble. Much less in CI - the existing part1_13 patch caps that ensemble at 20, so the subset sweep collapses to a single run. Tested at that size too.